### PR TITLE
Add Verilator tests for framing packages and ModelSim scripts

### DIFF
--- a/modelsim/compile_and_run.do
+++ b/modelsim/compile_and_run.do
@@ -1,0 +1,7 @@
+vlib work
+vlog ../../src/protocol/framings/constants/protocol_constants_pkg.sv \
+     ../../src/protocol/framings/utils/bytes_util_pkg.sv \
+     ../../src/protocol/framings/requests/*.sv \
+     ../../src/protocol/framings/responses/*.sv \
+     ../../tests/framings_tb.sv
+vsim -c framings_tb -do waves.do

--- a/modelsim/waves.do
+++ b/modelsim/waves.do
@@ -1,0 +1,3 @@
+add wave -r /*
+run -all
+quit

--- a/src/protocol/framings/requests/move_home_request_pkg.sv
+++ b/src/protocol/framings/requests/move_home_request_pkg.sv
@@ -19,7 +19,6 @@
 package move_home_request_pkg;
 
   import protocol_constants_pkg::*;
-  import bytes_util_pkg::*;
 
   parameter int FRAME_BITS = 72;
 
@@ -37,14 +36,14 @@ package move_home_request_pkg;
   // -------- Decoder (FRAME_BITS -> struct) --------
   function automatic move_home_req_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
     move_home_req_bytes_t r;
-    r.header   = get_byte#(FRAME_BITS)(raw, 0);
-    r.msgType  = get_byte#(FRAME_BITS)(raw, 1);
-    r.frameId  = get_byte#(FRAME_BITS)(raw, 2);
-    r.axisMask = get_byte#(FRAME_BITS)(raw, 3);
-    r.dirMask  = get_byte#(FRAME_BITS)(raw, 4);
-    r.vhome    = be16(get_byte#(FRAME_BITS)(raw,5), get_byte#(FRAME_BITS)(raw,6));
-    r.parity   = get_byte#(FRAME_BITS)(raw, 7);
-    r.tail     = get_byte#(FRAME_BITS)(raw, 8);
+    r.header   = raw[71:64];
+    r.msgType  = raw[63:56];
+    r.frameId  = raw[55:48];
+    r.axisMask = raw[47:40];
+    r.dirMask  = raw[39:32];
+    r.vhome    = raw[31:16];
+    r.parity   = raw[15:8];
+    r.tail     = raw[7:0];
     return r;
   endfunction
 

--- a/src/protocol/framings/requests/move_probe_level_request_pkg.sv
+++ b/src/protocol/framings/requests/move_probe_level_request_pkg.sv
@@ -18,7 +18,6 @@
 package move_probe_level_request_pkg;
 
   import protocol_constants_pkg::*;
-  import bytes_util_pkg::*;
 
   parameter int FRAME_BITS = 64;
 
@@ -35,13 +34,13 @@ package move_probe_level_request_pkg;
   // -------- Decoder (FRAME_BITS -> struct) --------
   function automatic move_probe_level_req_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
     move_probe_level_req_bytes_t r;
-    r.header   = get_byte#(FRAME_BITS)(raw, 0);
-    r.msgType  = get_byte#(FRAME_BITS)(raw, 1);
-    r.frameId  = get_byte#(FRAME_BITS)(raw, 2);
-    r.axisMask = get_byte#(FRAME_BITS)(raw, 3);
-    r.vprobe   = be16(get_byte#(FRAME_BITS)(raw,4), get_byte#(FRAME_BITS)(raw,5));
-    r.parity   = get_byte#(FRAME_BITS)(raw, 6);
-    r.tail     = get_byte#(FRAME_BITS)(raw, 7);
+    r.header   = raw[63:56];
+    r.msgType  = raw[55:48];
+    r.frameId  = raw[47:40];
+    r.axisMask = raw[39:32];
+    r.vprobe   = raw[31:16];
+    r.parity   = raw[15:8];
+    r.tail     = raw[7:0];
     return r;
   endfunction
 

--- a/src/protocol/framings/requests/move_queue_add_request_pkg.sv
+++ b/src/protocol/framings/requests/move_queue_add_request_pkg.sv
@@ -28,7 +28,6 @@
 package move_queue_add_request_pkg;
 
   import protocol_constants_pkg::*; // REQ_HEADER/REQ_TAIL, byte_t
-  import bytes_util_pkg::*;         // get_byte(), be16(), be32()
 
   // Largura total do vetor serializado em BITS (44 bytes = 352 bits)
   parameter int FRAME_BITS = 352;
@@ -62,37 +61,34 @@ package move_queue_add_request_pkg;
   function automatic move_queue_add_req_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
     move_queue_add_req_bytes_t r;
 
-    r.header   = get_byte#(FRAME_BITS)(raw, 0);
-    r.msgType  = get_byte#(FRAME_BITS)(raw, 1);
-    r.frameId  = get_byte#(FRAME_BITS)(raw, 2);
-    r.dirMask  = get_byte#(FRAME_BITS)(raw, 3);
+    r.header   = raw[351:344];
+    r.msgType  = raw[343:336];
+    r.frameId  = raw[335:328];
+    r.dirMask  = raw[327:320];
 
-    r.vx = be16(get_byte#(FRAME_BITS)(raw, 4), get_byte#(FRAME_BITS)(raw, 5));
-    r.sx = be32(get_byte#(FRAME_BITS)(raw, 6), get_byte#(FRAME_BITS)(raw, 7),
-                get_byte#(FRAME_BITS)(raw, 8), get_byte#(FRAME_BITS)(raw, 9));
+    r.vx = raw[319:304];
+    r.sx = raw[303:272];
 
-    r.vy = be16(get_byte#(FRAME_BITS)(raw,10), get_byte#(FRAME_BITS)(raw,11));
-    r.sy = be32(get_byte#(FRAME_BITS)(raw,12), get_byte#(FRAME_BITS)(raw,13),
-                get_byte#(FRAME_BITS)(raw,14), get_byte#(FRAME_BITS)(raw,15));
+    r.vy = raw[271:256];
+    r.sy = raw[255:224];
 
-    r.vz = be16(get_byte#(FRAME_BITS)(raw,16), get_byte#(FRAME_BITS)(raw,17));
-    r.sz = be32(get_byte#(FRAME_BITS)(raw,18), get_byte#(FRAME_BITS)(raw,19),
-                get_byte#(FRAME_BITS)(raw,20), get_byte#(FRAME_BITS)(raw,21));
+    r.vz = raw[223:208];
+    r.sz = raw[207:176];
 
-    r.kp_x = be16(get_byte#(FRAME_BITS)(raw,22), get_byte#(FRAME_BITS)(raw,23));
-    r.ki_x = be16(get_byte#(FRAME_BITS)(raw,24), get_byte#(FRAME_BITS)(raw,25));
-    r.kd_x = be16(get_byte#(FRAME_BITS)(raw,26), get_byte#(FRAME_BITS)(raw,27));
+    r.kp_x = raw[175:160];
+    r.ki_x = raw[159:144];
+    r.kd_x = raw[143:128];
 
-    r.kp_y = be16(get_byte#(FRAME_BITS)(raw,28), get_byte#(FRAME_BITS)(raw,29));
-    r.ki_y = be16(get_byte#(FRAME_BITS)(raw,30), get_byte#(FRAME_BITS)(raw,31));
-    r.kd_y = be16(get_byte#(FRAME_BITS)(raw,32), get_byte#(FRAME_BITS)(raw,33));
+    r.kp_y = raw[127:112];
+    r.ki_y = raw[111:96];
+    r.kd_y = raw[95:80];
 
-    r.kp_z = be16(get_byte#(FRAME_BITS)(raw,34), get_byte#(FRAME_BITS)(raw,35));
-    r.ki_z = be16(get_byte#(FRAME_BITS)(raw,36), get_byte#(FRAME_BITS)(raw,37));
-    r.kd_z = be16(get_byte#(FRAME_BITS)(raw,38), get_byte#(FRAME_BITS)(raw,39));
+    r.kp_z = raw[79:64];
+    r.ki_z = raw[63:48];
+    r.kd_z = raw[47:32];
 
-    r.parityByte = get_byte#(FRAME_BITS)(raw,40);
-    r.tail       = get_byte#(FRAME_BITS)(raw,41);
+    r.parityByte = raw[31:24];
+    r.tail       = raw[23:16];
     return r;
   endfunction
 

--- a/src/protocol/framings/responses/move_home_response_pkg.sv
+++ b/src/protocol/framings/responses/move_home_response_pkg.sv
@@ -19,7 +19,6 @@
 package move_home_response_pkg;
 
   import protocol_constants_pkg::*;
-  import bytes_util_pkg::*;
 
   parameter int FRAME_BITS = 64;
 
@@ -37,14 +36,14 @@ package move_home_response_pkg;
   // -------- Decoder (FRAME_BITS -> struct) --------
   function automatic move_home_resp_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
     move_home_resp_bytes_t r;
-    r.header       = get_byte#(FRAME_BITS)(raw, 0);
-    r.msgType      = get_byte#(FRAME_BITS)(raw, 1);
-    r.frameIdEcho  = get_byte#(FRAME_BITS)(raw, 2);
-    r.status       = get_byte#(FRAME_BITS)(raw, 3);
-    r.axisHomeMask = get_byte#(FRAME_BITS)(raw, 4);
-    r.errorFlags   = get_byte#(FRAME_BITS)(raw, 5);
-    r.parity       = get_byte#(FRAME_BITS)(raw, 6);
-    r.tail         = get_byte#(FRAME_BITS)(raw, 7);
+    r.header       = raw[63:56];
+    r.msgType      = raw[55:48];
+    r.frameIdEcho  = raw[47:40];
+    r.status       = raw[39:32];
+    r.axisHomeMask = raw[31:24];
+    r.errorFlags   = raw[23:16];
+    r.parity       = raw[15:8];
+    r.tail         = raw[7:0];
     return r;
   endfunction
 

--- a/src/protocol/framings/responses/move_probe_level_response_pkg.sv
+++ b/src/protocol/framings/responses/move_probe_level_response_pkg.sv
@@ -22,7 +22,6 @@
 package move_probe_level_response_pkg;
 
   import protocol_constants_pkg::*;
-  import bytes_util_pkg::*;
 
   parameter int FRAME_BITS = 160;
 
@@ -43,20 +42,17 @@ package move_probe_level_response_pkg;
   // -------- Decoder (FRAME_BITS -> struct) --------
   function automatic move_probe_level_resp_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
     move_probe_level_resp_bytes_t r;
-    r.header       = get_byte#(FRAME_BITS)(raw, 0);
-    r.msgType      = get_byte#(FRAME_BITS)(raw, 1);
-    r.frameIdEcho  = get_byte#(FRAME_BITS)(raw, 2);
-    r.status       = get_byte#(FRAME_BITS)(raw, 3);
-    r.axisDoneMask = get_byte#(FRAME_BITS)(raw, 4);
-    r.errorFlags   = get_byte#(FRAME_BITS)(raw, 5);
-    r.latchedPosX  = be32(get_byte#(FRAME_BITS)(raw,6), get_byte#(FRAME_BITS)(raw,7),
-                          get_byte#(FRAME_BITS)(raw,8), get_byte#(FRAME_BITS)(raw,9));
-    r.latchedPosY  = be32(get_byte#(FRAME_BITS)(raw,10), get_byte#(FRAME_BITS)(raw,11),
-                          get_byte#(FRAME_BITS)(raw,12), get_byte#(FRAME_BITS)(raw,13));
-    r.latchedPosZ  = be32(get_byte#(FRAME_BITS)(raw,14), get_byte#(FRAME_BITS)(raw,15),
-                          get_byte#(FRAME_BITS)(raw,16), get_byte#(FRAME_BITS)(raw,17));
-    r.parity       = get_byte#(FRAME_BITS)(raw,18);
-    r.tail         = get_byte#(FRAME_BITS)(raw,19);
+    r.header       = raw[159:152];
+    r.msgType      = raw[151:144];
+    r.frameIdEcho  = raw[143:136];
+    r.status       = raw[135:128];
+    r.axisDoneMask = raw[127:120];
+    r.errorFlags   = raw[119:112];
+    r.latchedPosX  = raw[111:80];
+    r.latchedPosY  = raw[79:48];
+    r.latchedPosZ  = raw[47:16];
+    r.parity       = raw[15:8];
+    r.tail         = raw[7:0];
     return r;
   endfunction
 

--- a/src/protocol/framings/responses/move_queue_add_response_pkg.sv
+++ b/src/protocol/framings/responses/move_queue_add_response_pkg.sv
@@ -22,7 +22,6 @@
 package move_queue_add_response_pkg;
 
   import protocol_constants_pkg::*; // RESP_HEADER/RESP_TAIL, byte_t
-  import bytes_util_pkg::*;         // get_byte()
 
   // Largura total do vetor serializado em BITS (6 bytes = 48 bits)
   parameter int FRAME_BITS = 48;
@@ -40,12 +39,12 @@ package move_queue_add_response_pkg;
   // -------- Decoder (FRAME_BITS -> struct) --------
   function automatic move_queue_add_resp_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
     move_queue_add_resp_bytes_t r;
-    r.header      = get_byte#(FRAME_BITS)(raw, 0);
-    r.msgType     = get_byte#(FRAME_BITS)(raw, 1);
-    r.frameIdEcho = get_byte#(FRAME_BITS)(raw, 2);
-    r.status      = get_byte#(FRAME_BITS)(raw, 3);
-    r.parityByte  = get_byte#(FRAME_BITS)(raw, 4);
-    r.tail        = get_byte#(FRAME_BITS)(raw, 5);
+    r.header      = raw[47:40];
+    r.msgType     = raw[39:32];
+    r.frameIdEcho = raw[31:24];
+    r.status      = raw[23:16];
+    r.parityByte  = raw[15:8];
+    r.tail        = raw[7:0];
     return r;
   endfunction
 

--- a/src/protocol/framings/responses/move_queue_status_response_pkg.sv
+++ b/src/protocol/framings/responses/move_queue_status_response_pkg.sv
@@ -29,7 +29,6 @@
 package move_queue_status_response_pkg;
 
   import protocol_constants_pkg::*; // RESP_HEADER/RESP_TAIL, byte_t
-  import bytes_util_pkg::*;         // get_byte()
 
   typedef struct packed {
     byte_t header;       // RESP_HEADER (0xAB)

--- a/src/protocol/framings/utils/bytes_util_pkg.sv
+++ b/src/protocol/framings/utils/bytes_util_pkg.sv
@@ -1,9 +1,33 @@
+// -----------------------------------------------------------------------------
+// bytes_util_pkg.sv
+//
+// Pacote de utilidades comuns para manipulação de vetores largos.
+// Inclui:
+//   - typedef byte_t
+//   - função get_byte(raw, idx): retorna um byte de posição idx em um vetor largo.
+//   - função be16(b_hi,b_lo): monta uint16 Big-Endian a partir de 2 bytes.
+//   - função be32(b3..b0): monta uint32 Big-Endian a partir de 4 bytes.
+//
+// Notas:
+//   - VECTOR_WIDTH_BITS: largura total do vetor de entrada, em BITS.
+//   - idx = 0 => retorna o byte mais significativo (MSB).
+//   - idx = 1 => próximo byte, e assim por diante até o LSB.
+// -----------------------------------------------------------------------------
+`ifndef BYTES_UTIL_PKG_SV
+`define BYTES_UTIL_PKG_SV
 package bytes_util_pkg;
+
   typedef logic [7:0] byte_t;
 
-  // Retorna o byte de posição idx de um vetor de 32 bits (idx 0 = MSB)
-  function automatic byte_t get_byte(input logic [31:0] raw, input int idx);
-    get_byte = raw[31 - 8*idx -: 8];
+  // Largura padrão dos vetores manipulados pelo pacote (em bits)
+  localparam int VECTOR_WIDTH_BITS = 440;
+
+  // Retorna o byte de posição idx de um vetor raw[VECTOR_WIDTH_BITS-1:0].
+  function automatic byte_t get_byte(
+      input logic [VECTOR_WIDTH_BITS-1:0] raw,
+      input int idx
+    );
+    get_byte = raw[VECTOR_WIDTH_BITS-1 - 8*idx -: 8];
   endfunction
 
   // Monta um uint16 Big-Endian a partir de 2 bytes
@@ -19,4 +43,6 @@ package bytes_util_pkg;
                                        input logic [7:0] b0);
     return {b3, b2, b1, b0};
   endfunction
+
 endpackage
+`endif

--- a/src/protocol/framings/utils/bytes_util_pkg.sv
+++ b/src/protocol/framings/utils/bytes_util_pkg.sv
@@ -1,32 +1,9 @@
-// -----------------------------------------------------------------------------
-// bytes_util_pkg.sv
-//
-// Pacote de utilidades comuns para manipulação de vetores largos.
-// Inclui:
-//   - typedef byte_t
-//   - função get_byte(raw, idx): retorna um byte de posição idx em um vetor largo.
-//   - função be16(b_hi,b_lo): monta uint16 Big-Endian a partir de 2 bytes.
-//   - função be32(b3..b0): monta uint32 Big-Endian a partir de 4 bytes.
-//
-// Notas:
-//   - VECTOR_WIDTH_BITS: largura total do vetor de entrada, em BITS.
-//   - idx = 0 => retorna o byte mais significativo (MSB).
-//   - idx = 1 => próximo byte, e assim por diante até o LSB.
-// -----------------------------------------------------------------------------
-`ifndef BYTES_UTIL_PKG_SV
-`define BYTES_UTIL_PKG_SV
 package bytes_util_pkg;
-
   typedef logic [7:0] byte_t;
 
-  // Retorna o byte de posição idx de um vetor raw[VECTOR_WIDTH_BITS-1:0].
-  function automatic byte_t get_byte
-    #(int VECTOR_WIDTH_BITS = 440) // largura total do vetor em bits (default 440 bits)
-    (
-      input logic [VECTOR_WIDTH_BITS-1:0] raw,
-      input int idx
-    );
-    get_byte = raw[VECTOR_WIDTH_BITS-1 - 8*idx -: 8];
+  // Retorna o byte de posição idx de um vetor de 32 bits (idx 0 = MSB)
+  function automatic byte_t get_byte(input logic [31:0] raw, input int idx);
+    get_byte = raw[31 - 8*idx -: 8];
   endfunction
 
   // Monta um uint16 Big-Endian a partir de 2 bytes
@@ -42,6 +19,4 @@ package bytes_util_pkg;
                                        input logic [7:0] b0);
     return {b3, b2, b1, b0};
   endfunction
-
 endpackage
-`endif

--- a/tests/framings_tb.sv
+++ b/tests/framings_tb.sv
@@ -1,0 +1,235 @@
+`timescale 1ns/1ps
+module framings_tb;
+  import bytes_util_pkg::*;
+
+  task automatic test_bytes_util();
+    logic [31:0] vec;
+    vec = 32'hAABBCCDD;
+    assert(get_byte(vec,0) == 8'hAA);
+    assert(get_byte(vec,1) == 8'hBB);
+    assert(get_byte(vec,2) == 8'hCC);
+    assert(get_byte(vec,3) == 8'hDD);
+    assert(be16(8'h12,8'h34) == 16'h1234);
+    assert(be32(8'hDE,8'hAD,8'hBE,8'hEF) == 32'hDEADBEEF);
+  endtask
+
+  task automatic test_start_move_request();
+    start_move_request_pkg::start_move_req_bytes_t r;
+    logic [31:0] raw;
+    start_move_request_pkg::start_move_req_bytes_t d;
+    r = start_move_request_pkg::make_default();
+    r.frameId = 8'h11;
+    raw = start_move_request_pkg::encoder(r);
+    d = start_move_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_home_request();
+    move_home_request_pkg::move_home_req_bytes_t r;
+    logic [71:0] raw;
+    move_home_request_pkg::move_home_req_bytes_t d;
+    r = move_home_request_pkg::make_default();
+    r.frameId = 8'h22;
+    r.axisMask = 8'h07;
+    r.dirMask = 8'h05;
+    r.vhome = 16'h1234;
+    r = move_home_request_pkg::set_parity(r);
+    assert(move_home_request_pkg::check_parity(r));
+    raw = move_home_request_pkg::encoder(r);
+    d = move_home_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_probe_level_request();
+    move_probe_level_request_pkg::move_probe_level_req_bytes_t r;
+    logic [63:0] raw;
+    move_probe_level_request_pkg::move_probe_level_req_bytes_t d;
+    r = move_probe_level_request_pkg::make_default();
+    r.frameId = 8'h33;
+    r.axisMask = 8'h07;
+    r.vprobe = 16'h5678;
+    r = move_probe_level_request_pkg::set_parity(r);
+    assert(move_probe_level_request_pkg::check_parity(r));
+    raw = move_probe_level_request_pkg::encoder(r);
+    d = move_probe_level_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_fpga_status_request();
+    fpga_status_request_pkg::request_fpga_status_bytes_t r;
+    logic [31:0] raw;
+    fpga_status_request_pkg::request_fpga_status_bytes_t d;
+    r = fpga_status_request_pkg::make_default();
+    r.frameId = 8'h44;
+    raw = fpga_status_request_pkg::encoder(r);
+    d = fpga_status_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_queue_status_request();
+    move_queue_status_request_pkg::move_queue_status_bytes_t r;
+    logic [31:0] raw;
+    move_queue_status_request_pkg::move_queue_status_bytes_t d;
+    r = move_queue_status_request_pkg::make_default();
+    r.frameId = 8'h55;
+    raw = move_queue_status_request_pkg::encoder(r);
+    d = move_queue_status_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_end_request();
+    move_end_request_pkg::move_end_req_bytes_t r;
+    logic [31:0] raw;
+    move_end_request_pkg::move_end_req_bytes_t d;
+    r = move_end_request_pkg::make_default();
+    r.frameId = 8'h66;
+    raw = move_end_request_pkg::encoder(r);
+    d = move_end_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_queue_add_request();
+    move_queue_add_request_pkg::move_queue_add_req_bytes_t r;
+    logic [351:0] raw;
+    move_queue_add_request_pkg::move_queue_add_req_bytes_t d;
+    r = move_queue_add_request_pkg::make_default();
+    r.frameId = 8'h77;
+    r.dirMask = 8'h07;
+    r.vx = 16'h0102; r.sx = 32'h03040506;
+    r.vy = 16'h0708; r.sy = 32'h090A0B0C;
+    r.vz = 16'h0D0E; r.sz = 32'h0F101112;
+    r.kp_x = 16'h1314; r.ki_x = 16'h1516; r.kd_x = 16'h1718;
+    r.kp_y = 16'h191A; r.ki_y = 16'h1B1C; r.kd_y = 16'h1D1E;
+    r.kp_z = 16'h1F20; r.ki_z = 16'h2122; r.kd_z = 16'h2324;
+    r = move_queue_add_request_pkg::set_parity(r);
+    assert(move_queue_add_request_pkg::check_parity(r));
+    raw = move_queue_add_request_pkg::encoder(r);
+    d = move_queue_add_request_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_start_move_response();
+    start_move_response_pkg::start_move_resp_bytes_t r;
+    logic [31:0] raw;
+    start_move_response_pkg::start_move_resp_bytes_t d;
+    r = start_move_response_pkg::make_default();
+    r.frameIdEcho = 8'h10;
+    raw = start_move_response_pkg::encoder(r);
+    d = start_move_response_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_end_response();
+    move_end_response_pkg::move_end_resp_bytes_t r;
+    logic [31:0] raw;
+    move_end_response_pkg::move_end_resp_bytes_t d;
+    r = move_end_response_pkg::make_default();
+    r.frameIdEcho = 8'h20;
+    raw = move_end_response_pkg::encoder(r);
+    d = move_end_response_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_home_response();
+    move_home_response_pkg::move_home_resp_bytes_t r;
+    logic [63:0] raw;
+    move_home_response_pkg::move_home_resp_bytes_t d;
+    r = move_home_response_pkg::make_default();
+    r.frameIdEcho = 8'h30;
+    r.axisHomeMask = 8'h07;
+    r.errorFlags = 8'h01;
+    r = move_home_response_pkg::set_parity(r);
+    assert(move_home_response_pkg::check_parity(r));
+    raw = move_home_response_pkg::encoder(r);
+    d = move_home_response_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_queue_status_response();
+    move_queue_status_response_pkg::move_queue_status_resp_bytes_t r;
+    logic [95:0] raw;
+    move_queue_status_response_pkg::move_queue_status_resp_bytes_t d;
+    r = move_queue_status_response_pkg::make_default();
+    r.frameIdEcho = 8'h40;
+    r.status = 8'd2;
+    r.pctX = 8'd10; r.pctY = 8'd20; r.pctZ = 8'd30;
+    r = move_queue_status_response_pkg::set_parity(r);
+    assert(move_queue_status_response_pkg::check_parity(r));
+    raw = move_queue_status_response_pkg::encoder(r);
+    d = move_queue_status_response_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_fpga_status_response();
+    fpga_status_response_pkg::response_fpga_status_bytes_t r;
+    logic [95:0] raw;
+    fpga_status_response_pkg::response_fpga_status_bytes_t d;
+    r = fpga_status_response_pkg::make_default();
+    r.frameIdEcho = 8'h50;
+    r.status = 8'd1;
+    r.mode = 8'd2;
+    r = fpga_status_response_pkg::set_parity(r);
+    assert(fpga_status_response_pkg::check_parity(r));
+    raw = fpga_status_response_pkg::encoder(r);
+    d = fpga_status_response_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  task automatic test_move_queue_add_response();
+    move_queue_add_response_pkg::move_queue_add_resp_bytes_t r;
+    logic [47:0] raw;
+    move_queue_add_response_pkg::move_queue_add_resp_bytes_t d;
+    move_queue_add_response_pkg::move_queue_add_resp_bytes_t e;
+    logic [47:0] raw_e;
+    move_queue_add_response_pkg::move_queue_add_resp_bytes_t d_e;
+    r = move_queue_add_response_pkg::make_default_ok(8'h60);
+    r = move_queue_add_response_pkg::set_parity(r);
+    assert(move_queue_add_response_pkg::check_parity(r));
+    raw = move_queue_add_response_pkg::encoder(r);
+    d = move_queue_add_response_pkg::decoder(raw);
+    assert(d == r);
+    e = move_queue_add_response_pkg::make_default_err(8'h61);
+    e = move_queue_add_response_pkg::set_parity(e);
+    assert(move_queue_add_response_pkg::check_parity(e));
+    raw_e = move_queue_add_response_pkg::encoder(e);
+    d_e = move_queue_add_response_pkg::decoder(raw_e);
+    assert(d_e == e);
+  endtask
+
+  task automatic test_move_probe_level_response();
+    move_probe_level_response_pkg::move_probe_level_resp_bytes_t r;
+    logic [159:0] raw;
+    move_probe_level_response_pkg::move_probe_level_resp_bytes_t d;
+    r = move_probe_level_response_pkg::make_default();
+    r.frameIdEcho = 8'h70;
+    r.axisDoneMask = 8'h07;
+    r.latchedPosX = 32'h01020304;
+    r.latchedPosY = 32'h05060708;
+    r.latchedPosZ = 32'h090A0B0C;
+    r = move_probe_level_response_pkg::set_parity(r);
+    assert(move_probe_level_response_pkg::check_parity(r));
+    raw = move_probe_level_response_pkg::encoder(r);
+    d = move_probe_level_response_pkg::decoder(raw);
+    assert(d == r);
+  endtask
+
+  initial begin
+    test_bytes_util();
+    test_start_move_request();
+    test_move_home_request();
+    test_move_probe_level_request();
+    test_fpga_status_request();
+    test_move_queue_status_request();
+    test_move_end_request();
+    test_move_queue_add_request();
+    test_start_move_response();
+    test_move_end_response();
+    test_move_home_response();
+    test_move_queue_status_response();
+    test_fpga_status_response();
+    test_move_queue_add_response();
+    test_move_probe_level_response();
+    $display("All framing tests passed");
+    $finish;
+  end
+endmodule

--- a/tests/framings_tb.sv
+++ b/tests/framings_tb.sv
@@ -3,8 +3,8 @@ module framings_tb;
   import bytes_util_pkg::*;
 
   task automatic test_bytes_util();
-    logic [31:0] vec;
-    vec = 32'hAABBCCDD;
+    logic [439:0] vec;
+    vec = {32'hAABBCCDD, {408{1'b0}}};
     assert(get_byte(vec,0) == 8'hAA);
     assert(get_byte(vec,1) == 8'hBB);
     assert(get_byte(vec,2) == 8'hCC);


### PR DESCRIPTION
## Summary
- refactor framing packages to use direct bit slicing, easing Verilator compatibility
- create comprehensive framings testbench and ModelSim scripts
- add byte utility helpers

## Testing
- `verilator --sv --binary -Wno-TIMESCALEMOD -Wno-WIDTHEXPAND -Wno-WIDTHTRUNC --top-module framings_tb src/protocol/framings/constants/protocol_constants_pkg.sv src/protocol/framings/utils/bytes_util_pkg.sv src/protocol/framings/requests/*.sv src/protocol/framings/responses/*.sv tests/framings_tb.sv`
- `obj_dir/Vframings_tb`


------
https://chatgpt.com/codex/tasks/task_e_68ad24b345708326b18f2f617966c0a8