### PR TITLE
test: cover MOVE_HOME parser error cases

### DIFF
--- a/src/protocol/parsers/requests/move_home_req_parser_pkg.sv
+++ b/src/protocol/parsers/requests/move_home_req_parser_pkg.sv
@@ -1,0 +1,160 @@
+// -----------------------------------------------------------------------------
+// move_home_req_parser_pkg.sv
+//
+// Parser orientado a bytes para frames MOVE_HOME. Cada chamada de `feed`
+// recebe um único byte, permitindo reconstruir o frame mesmo quando o
+// transporte entrega dados de forma serial. Todos os campos são validados
+// contra as constantes do protocolo: o header e o tipo de mensagem devem
+// corresponder aos valores fixos, o byte de paridade deve ser o XOR dos bytes
+// do payload e o tail marca o fim do frame. Quando todas as verificações passam
+// `frame_valid` é acionado e a struct `move_home_req_bytes_t` preenchida é
+// retornada.
+// -----------------------------------------------------------------------------
+`ifndef MOVE_HOME_REQ_PARSER_PKG_SV
+`define MOVE_HOME_REQ_PARSER_PKG_SV
+package move_home_req_parser_pkg;
+  import move_home_request_pkg::*;
+  import protocol_constants_pkg::*;
+
+  // Estados da FSM para recepção sequencial dos nove bytes do frame
+  typedef enum logic [3:0] {
+    S_HEADER,  // espera marcador REQ_HEADER
+    S_MSGTYPE, // espera identificador MOVE_HOME_TYPE
+    S_FRAMEID, // byte de ID do frame
+    S_AXIS,    // byte de máscara de eixos
+    S_DIR,     // byte de máscara de direções
+    S_VH_HI,   // byte alto da velocidade vhome
+    S_VH_LO,   // byte baixo da velocidade vhome
+    S_PARITY,  // byte de paridade (XOR de msgType..vhome)
+    S_TAIL     // espera marcador REQ_TAIL
+  } parser_state_t;
+
+  // Contexto do parser com estado da FSM e frame parcialmente montado
+  typedef struct packed {
+    parser_state_t        state;       // estado atual do parser
+    move_home_req_bytes_t frame;       // frame em construção
+    byte_t                parity_calc; // acumulador de paridade
+  } parser_ctx_t;
+
+  // Cria um contexto novo pronto para receber um novo frame
+  function automatic parser_ctx_t init();
+    parser_ctx_t ctx;
+    ctx.state       = S_HEADER;                              // aguarda cabeçalho
+    ctx.frame       = move_home_request_pkg::make_default(); // zera todos os campos
+    ctx.parity_calc = 8'h00;                                 // zera paridade
+    return ctx;
+  endfunction
+
+  // Alimenta o parser com um byte. O contexto retornado deve ser armazenado
+  // pelo chamador para a próxima invocação. `frame_valid` é acionado em
+  // exatamente uma chamada quando um frame completo é recebido, enquanto
+  // `frame_error` sinaliza qualquer violação de protocolo. Após qualquer um
+  // desses eventos a máquina de estados retorna a `S_HEADER` pronta para o
+  // próximo frame.
+  function automatic parser_ctx_t feed(
+      input  parser_ctx_t          in_ctx,
+      input  byte_t                data,
+      output logic                 frame_valid,
+      output logic                 frame_error,
+      output move_home_req_bytes_t out_frame
+  );
+    parser_ctx_t ctx = in_ctx;
+    frame_valid = 1'b0;
+    frame_error = 1'b0;
+    out_frame   = ctx.frame;
+
+    case (ctx.state)
+      // Verifica cabeçalho do frame
+      S_HEADER: begin
+        if (data == REQ_HEADER) begin
+          ctx.frame.header = data;
+          ctx.state        = S_MSGTYPE;
+          ctx.parity_calc  = 8'h00;
+        end else begin
+          // byte inicial inválido, sinaliza erro e permanece em HEADER
+          frame_error = 1'b1;
+        end
+      end
+
+      // Verifica se o tipo de mensagem é MOVE_HOME
+      S_MSGTYPE: begin
+        if (data == MOVE_HOME_TYPE) begin
+          ctx.frame.msgType = data;
+          ctx.parity_calc   = data;   // inicia paridade com msgType
+          ctx.state         = S_FRAMEID;
+        end else begin
+          frame_error = 1'b1;
+          ctx.state   = S_HEADER;     // ressincroniza
+        end
+      end
+
+      // Acumula o ID do frame
+      S_FRAMEID: begin
+        ctx.frame.frameId = data;
+        ctx.parity_calc  ^= data;
+        ctx.state         = S_AXIS;
+      end
+
+      // Byte de máscara de eixos
+      S_AXIS: begin
+        ctx.frame.axisMask = data;
+        ctx.parity_calc   ^= data;
+        ctx.state          = S_DIR;
+      end
+
+      // Byte de máscara de direções
+      S_DIR: begin
+        ctx.frame.dirMask = data;
+        ctx.parity_calc  ^= data;
+        ctx.state         = S_VH_HI;
+      end
+
+      // Byte alto da velocidade vhome
+      S_VH_HI: begin
+        ctx.frame.vhome[15:8] = data;
+        ctx.parity_calc      ^= data;
+        ctx.state             = S_VH_LO;
+      end
+
+      // Byte baixo da velocidade vhome
+      S_VH_LO: begin
+        ctx.frame.vhome[7:0] = data;
+        ctx.parity_calc     ^= data;
+        ctx.state            = S_PARITY;
+      end
+
+      // Compara paridade calculada com a recebida
+      S_PARITY: begin
+        ctx.frame.parity = data;
+        if (data == ctx.parity_calc) begin
+          ctx.state = S_TAIL;
+        end else begin
+          frame_error = 1'b1;
+          ctx.state   = S_HEADER;
+        end
+      end
+
+      // Byte final tail completa o frame
+      S_TAIL: begin
+        if (data == REQ_TAIL) begin
+          ctx.frame.tail = data;
+          frame_valid    = 1'b1;
+          out_frame      = ctx.frame;
+        end else begin
+          frame_error = 1'b1;
+        end
+        ctx.state = S_HEADER; // reinicia para o próximo frame
+      end
+
+      // Não deveria acontecer, mas reinicia em qualquer estado inesperado
+      default: begin
+        frame_error = 1'b1;
+        ctx.state   = S_HEADER;
+      end
+    endcase
+
+    return ctx;
+  endfunction
+
+endpackage
+`endif

--- a/tb/tests/move_home_request_parser_tb.sv
+++ b/tb/tests/move_home_request_parser_tb.sv
@@ -1,0 +1,76 @@
+`timescale 1ns/1ps
+`define TEST_ASSERT(cond, name) if(!(cond)) begin $display("Falha: %s", name); $finish; end
+
+module move_home_request_parser_tb;
+  import protocol_constants_pkg::*;
+  import move_home_request_pkg::*;
+  import move_home_req_parser_pkg::*;
+
+  initial begin
+    move_home_req_bytes_t in;
+    move_home_req_bytes_t out;
+    parser_ctx_t ctx;
+    logic frame_valid;
+    logic frame_error;
+    logic [71:0] raw;
+    byte_t b;
+
+    // Constrói frame válido
+    in = make_default();
+    in.frameId  = 8'h0A;
+    in.axisMask = 8'h07;
+    in.dirMask  = 8'h05;
+    in.vhome    = 16'h1234;
+    in = set_parity(in);
+
+    ctx = init();
+    raw = encoder(in);
+    for (int i = 0; i < 9; i++) begin
+      b   = raw[71 - i*8 -: 8];
+      ctx = feed(ctx, b, frame_valid, frame_error, out);
+      if (i < 8) begin
+        `TEST_ASSERT(!frame_valid, $sformatf("no_valid_%0d", i));
+        `TEST_ASSERT(!frame_error, $sformatf("no_error_%0d", i));
+      end else begin
+        `TEST_ASSERT(frame_valid, "frame_valid");
+        `TEST_ASSERT(!frame_error, "no_error_final");
+        `TEST_ASSERT(out == in, "frame_match");
+      end
+    end
+
+    // Corrompe a paridade e processa novamente
+    in.parity ^= 8'hFF;
+    raw = encoder(in);
+    ctx = init();
+    for (int i = 0; i < 8; i++) begin
+      b   = raw[71 - i*8 -: 8];
+      ctx = feed(ctx, b, frame_valid, frame_error, out);
+      if (i == 7) begin
+        `TEST_ASSERT(frame_error, "parity_error_flag");
+        `TEST_ASSERT(!frame_valid, "parity_no_valid");
+      end
+    end
+
+    // Corrompe o tail e processa novamente
+    in = make_default();
+    in.frameId  = 8'h0A;
+    in.axisMask = 8'h07;
+    in.dirMask  = 8'h05;
+    in.vhome    = 16'h1234;
+    in = set_parity(in);
+    raw = encoder(in);
+    raw[7:0] = 8'h00; // tail incorreto
+    ctx = init();
+    for (int i = 0; i < 9; i++) begin
+      b   = raw[71 - i*8 -: 8];
+      ctx = feed(ctx, b, frame_valid, frame_error, out);
+      if (i == 8) begin
+        `TEST_ASSERT(frame_error, "tail_error_flag");
+        `TEST_ASSERT(!frame_valid, "tail_no_valid");
+      end
+    end
+
+    $display("Sucesso: test_move_home_request_parser");
+    $finish;
+  end
+endmodule

--- a/tb/verilator/run_verilator_parser_tests.py
+++ b/tb/verilator/run_verilator_parser_tests.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import subprocess
+from pathlib import Path
+import sys
+
+root = Path(__file__).resolve().parents[2]
+
+parser_root = root / "src" / "protocol" / "parsers" / "requests"
+framing_root = root / "src" / "protocol" / "framings"
+
+tb_file = root / "tb" / "tests" / "move_home_request_parser_tb.sv"
+
+files = []
+files.extend(sorted((framing_root / "constants").glob("*.sv")))
+files.extend(sorted((framing_root / "requests").glob("move_home_request_pkg.sv")))
+files.extend(sorted(parser_root.glob("*.sv")))
+files.append(tb_file)
+
+subprocess.run(["rm", "-rf", str(root / "obj_dir")])
+
+cmd = [
+    "verilator",
+    "--sv",
+    "--binary",
+    "--top-module",
+    "move_home_request_parser_tb",
+    "-Wno-TIMESCALEMOD",
+    "-Wno-WIDTHEXPAND",
+] + [str(f) for f in files]
+
+compile = subprocess.run(cmd, cwd=root, capture_output=True, text=True)
+print(compile.stdout)
+if compile.returncode != 0:
+    print(compile.stderr)
+    sys.exit(compile.returncode)
+
+proc = subprocess.run(["./obj_dir/Vmove_home_request_parser_tb"], cwd=root, capture_output=True, text=True)
+print(proc.stdout)
+if proc.returncode != 0:
+    print(proc.stderr)
+    sys.exit(proc.returncode)
+
+if "Sucesso: test_move_home_request_parser" not in proc.stdout:
+    print("Falha: test_move_home_request_parser")
+    sys.exit(1)
+
+print("Todos os testes de parser passaram com sucesso.")


### PR DESCRIPTION
## Summary
- extend MOVE_HOME parser testbench to assert parity mismatch and tail byte errors

## Testing
- `python tb/verilator/run_verilator_parser_tests.py`
- `python tb/verilator/run_verilator_framings_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae06283f1883269f3da621106ac1c2