### PR TITLE
Fix motion_service test benches for verilator

### DIFF
--- a/tb/tests/spi_full_flow_motion_10_moves_tb.sv
+++ b/tb/tests/spi_full_flow_motion_10_moves_tb.sv
@@ -105,6 +105,7 @@ module spi_full_flow_motion_10_moves_tb;
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
 

--- a/tb/tests/spi_full_flow_motion_basic_tb.sv
+++ b/tb/tests/spi_full_flow_motion_basic_tb.sv
@@ -48,6 +48,7 @@ module spi_full_flow_motion_basic_tb;
   logic tmc_step_x, tmc_dir_x, tmc_enn_x;
   logic tmc_step_y, tmc_dir_y, tmc_enn_y;
   logic tmc_step_z, tmc_dir_z, tmc_enn_z;
+  logic moving;
 
   // TX path (stream -> fifo -> bytes)
   spi_fifo_if #(.DEPTH(TX_FIFO_DEPTH), .DROP_OLD_ON_FULL(1)) tx_fifo();
@@ -107,6 +108,7 @@ module spi_full_flow_motion_basic_tb;
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(moving),
     .tx_stream(motion_stream)
   );
 

--- a/tb/tests/spi_full_flow_motion_early_end_tb.sv
+++ b/tb/tests/spi_full_flow_motion_early_end_tb.sv
@@ -56,6 +56,7 @@ module spi_full_flow_motion_early_end_tb;
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
   assign streams[0].valid = motion_stream.valid;

--- a/tb/tests/spi_full_flow_motion_home_tb.sv
+++ b/tb/tests/spi_full_flow_motion_home_tb.sv
@@ -109,6 +109,7 @@ module spi_full_flow_motion_home_tb;
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
 

--- a/tb/tests/spi_full_flow_motion_multiaxis_tb.sv
+++ b/tb/tests/spi_full_flow_motion_multiaxis_tb.sv
@@ -61,6 +61,7 @@ module spi_full_flow_motion_multiaxis_tb;
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
   assign streams[0].valid = motion_stream.valid;

--- a/tb/tests/spi_full_flow_tick_count_tb.sv
+++ b/tb/tests/spi_full_flow_tick_count_tb.sv
@@ -58,6 +58,7 @@ module spi_full_flow_tick_count_tb;
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
   assign streams[0].valid = motion_stream.valid;


### PR DESCRIPTION
## Summary
- connect `o_moving` output in all motion service testbenches

## Testing
- `./run_tests.sh verilator`

------
https://chatgpt.com/codex/tasks/task_e_68bcbedc833c8326ba8e1fbfb4151f48