### PR TITLE
Add indexed homing support and home status frame

### DIFF
--- a/spi_cnc_controller.gprj
+++ b/spi_cnc_controller.gprj
@@ -25,6 +25,7 @@
         <File path="src/protocol/framings/responses/led_control_response_pkg.sv" type="file.verilog" enable="1"/>
         <File path="src/protocol/framings/responses/move_end_response_pkg.sv" type="file.verilog" enable="1"/>
         <File path="src/protocol/framings/responses/move_home_response_pkg.sv" type="file.verilog" enable="1"/>
+        <File path="src/protocol/framings/responses/home_status_response_pkg.sv" type="file.verilog" enable="1"/>
         <File path="src/protocol/framings/responses/move_probe_level_response_pkg.sv" type="file.verilog" enable="1"/>
         <File path="src/protocol/framings/responses/move_queue_add_response_pkg.sv" type="file.verilog" enable="1"/>
         <File path="src/protocol/framings/responses/move_queue_status_response_pkg.sv" type="file.verilog" enable="1"/>
@@ -45,6 +46,7 @@
         <File path="src/services/integrations/rtl/byte_fifo_sync_rtl.sv" type="file.verilog" enable="1"/>
         <File path="src/services/led/led_service.sv" type="file.verilog" enable="1"/>
         <File path="src/services/motion/axis_controller_service.sv" type="file.verilog" enable="1"/>
+        <File path="src/services/motion/axis_home_service.sv" type="file.verilog" enable="1"/>
         <File path="src/services/motion/motion_service.sv" type="file.verilog" enable="1"/>
         <File path="src/services/motion/pid_axis_service.sv" type="file.verilog" enable="1"/>
         <File path="src/services/motion/pid_service.sv" type="file.verilog" enable="1"/>

--- a/src/protocol/framings/constants/protocol_constants_pkg.sv
+++ b/src/protocol/framings/constants/protocol_constants_pkg.sv
@@ -62,6 +62,11 @@ package protocol_constants_pkg;
   // FPGA_STATUS
   // ---------------------------
   localparam byte_t FPGA_STATUS_TYPE   = 8'h20;
+
+  // ---------------------------
+  // HOME_STATUS
+  // ---------------------------
+  localparam byte_t HOME_STATUS_TYPE   = 8'h21;
   
 endpackage
 `endif

--- a/src/protocol/framings/responses/home_status_response_pkg.sv
+++ b/src/protocol/framings/responses/home_status_response_pkg.sv
@@ -1,0 +1,128 @@
+// -----------------------------------------------------------------------------
+// home_status_response_pkg.sv
+//
+// Frame RESPONSE HOME_STATUS (18B / 144 bits)
+// Reporta o status de homing e offsets capturados por eixo.
+//
+// Layout (Big-Endian por byte; offsets em bytes):
+//  0: Header(AB)
+//  1: MsgType(21)         // HOME_STATUS_TYPE
+//  2: FrameID_Echo        // eco do request
+//  3: AxisMask            // b0=X, b1=Y, b2=Z válidos
+//  4: PosRelX[15:8]
+//  5: PosRelX[7:0]
+//  6: HomeOffX[15:8]
+//  7: HomeOffX[7:0]
+//  8: PosRelY[15:8]
+//  9: PosRelY[7:0]
+// 10: HomeOffY[15:8]
+// 11: HomeOffY[7:0]
+// 12: PosRelZ[15:8]
+// 13: PosRelZ[7:0]
+// 14: HomeOffZ[15:8]
+// 15: HomeOffZ[7:0]
+// 16: Parity             // XOR bytes 1..15
+// 17: Tail(54)
+// -----------------------------------------------------------------------------
+`ifndef HOME_STATUS_RESPONSE_PKG_SV
+`define HOME_STATUS_RESPONSE_PKG_SV
+package home_status_response_pkg;
+
+  import protocol_constants_pkg::*;
+
+  localparam int FRAME_BITS = 144;
+
+  typedef struct packed {
+    byte_t header;      // RESP_HEADER (0xAB)
+    byte_t msgType;     // HOME_STATUS_TYPE (0x21)
+    byte_t frameIdEcho; // eco do request
+    byte_t axisMask;    // eixos com home válido
+    logic [15:0] posRelX;
+    logic [15:0] homeOffX;
+    logic [15:0] posRelY;
+    logic [15:0] homeOffY;
+    logic [15:0] posRelZ;
+    logic [15:0] homeOffZ;
+    byte_t parity;      // XOR bytes 1..15
+    byte_t tail;        // RESP_TAIL (0x54)
+  } home_status_resp_bytes_t;
+
+  // Decoder (FRAME_BITS -> struct)
+  function automatic home_status_resp_bytes_t decoder(input logic [FRAME_BITS-1:0] raw);
+    home_status_resp_bytes_t r;
+    r.header      = raw[143:136];
+    r.msgType     = raw[135:128];
+    r.frameIdEcho = raw[127:120];
+    r.axisMask    = raw[119:112];
+    r.posRelX     = raw[111:96];
+    r.homeOffX    = raw[95:80];
+    r.posRelY     = raw[79:64];
+    r.homeOffY    = raw[63:48];
+    r.posRelZ     = raw[47:32];
+    r.homeOffZ    = raw[31:16];
+    r.parity      = raw[15:8];
+    r.tail        = raw[7:0];
+    return r;
+  endfunction
+
+  // Encoder (struct -> FRAME_BITS)
+  function automatic logic [FRAME_BITS-1:0] encoder(input home_status_resp_bytes_t r);
+    logic [FRAME_BITS-1:0] v;
+    v = {
+      r.header,
+      r.msgType,
+      r.frameIdEcho,
+      r.axisMask,
+      r.posRelX,
+      r.homeOffX,
+      r.posRelY,
+      r.homeOffY,
+      r.posRelZ,
+      r.homeOffZ,
+      r.parity,
+      r.tail
+    };
+    return v;
+  endfunction
+
+  // Parity
+  function automatic byte_t calc_parity(input home_status_resp_bytes_t f);
+    return f.msgType ^ f.frameIdEcho ^ f.axisMask ^
+           f.posRelX[15:8] ^ f.posRelX[7:0] ^
+           f.homeOffX[15:8] ^ f.homeOffX[7:0] ^
+           f.posRelY[15:8] ^ f.posRelY[7:0] ^
+           f.homeOffY[15:8] ^ f.homeOffY[7:0] ^
+           f.posRelZ[15:8] ^ f.posRelZ[7:0] ^
+           f.homeOffZ[15:8] ^ f.homeOffZ[7:0];
+  endfunction
+
+  function automatic logic check_parity(input home_status_resp_bytes_t f);
+    return (f.parity == calc_parity(f));
+  endfunction
+
+  function automatic home_status_resp_bytes_t set_parity(input home_status_resp_bytes_t in);
+    home_status_resp_bytes_t r = in;
+    r.parity = calc_parity(in);
+    return r;
+  endfunction
+
+  // Default seguro
+  function automatic home_status_resp_bytes_t make_default();
+    home_status_resp_bytes_t r;
+    r.header      = RESP_HEADER;
+    r.msgType     = HOME_STATUS_TYPE;
+    r.frameIdEcho = 8'd0;
+    r.axisMask    = 8'd0;
+    r.posRelX     = 16'd0;
+    r.homeOffX    = 16'd0;
+    r.posRelY     = 16'd0;
+    r.homeOffY    = 16'd0;
+    r.posRelZ     = 16'd0;
+    r.homeOffZ    = 16'd0;
+    r.parity      = 8'd0; // ajustado por set_parity
+    r.tail        = RESP_TAIL;
+    return r;
+  endfunction
+
+endpackage
+`endif

--- a/src/services/motion/axis_home_service.sv
+++ b/src/services/motion/axis_home_service.sv
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------------
+// axis_home_service.sv
+//
+// FSM de homing por eixo. Gerencia estágios COARSE (sensor de proximidade)
+// e FINE (pulso de índice Z) antes de sinalizar DONE.
+// Não gera movimento; apenas monitora sinais físicos.
+// -----------------------------------------------------------------------------
+`ifndef AXIS_HOME_SERVICE_SV
+`define AXIS_HOME_SERVICE_SV
+module axis_home_service #(
+    parameter bit HOMING_USE_INDEX = 1'b1
+  )(
+    input  logic clk,
+    input  logic rst_n,
+    input  logic start,        // pulso para iniciar homing
+    input  logic prox_active,  // sensor de proximidade (nível)
+    input  logic idx_pulse,    // pulso de índice do encoder
+    output logic homing,       // 1 enquanto COARSE/FINE
+    output logic done_pulse    // pulso ao concluir
+  );
+
+  typedef enum logic [1:0] {IDLE, COARSE, FINE, DONE} state_t;
+  state_t state, state_n;
+
+  // detecção de borda de PROX para evitar início imediato
+  logic prox_q;
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) prox_q <= 1'b0;
+    else prox_q <= prox_active;
+  end
+  wire prox_rise = prox_active & ~prox_q;
+
+  // Estado
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) state <= IDLE;
+    else state <= state_n;
+  end
+
+  // saída homing
+  assign homing = (state != IDLE);
+
+  // próxima transição
+  always_comb begin
+    state_n = state;
+    done_pulse = 1'b0;
+    case (state)
+      IDLE: begin
+        if (start) state_n = COARSE;
+      end
+      COARSE: begin
+        if (prox_rise || prox_active) begin
+          if (HOMING_USE_INDEX) state_n = FINE;
+          else                  state_n = DONE;
+        end
+      end
+      FINE: begin
+        if (idx_pulse || !HOMING_USE_INDEX) state_n = DONE;
+      end
+      DONE: begin
+        done_pulse = 1'b1;
+        state_n = IDLE;
+      end
+      default: state_n = IDLE;
+    endcase
+  end
+endmodule
+`endif

--- a/src/services/motion/motion_service.sv
+++ b/src/services/motion/motion_service.sv
@@ -14,7 +14,8 @@ module motion_service #(
     // Configuração elétrica dos sensores de proximidade por eixo
     // PROX_IS_PNP=1 => PNP; 0 => NPN. PROX_IS_NO=1 => Normalmente Aberto; 0 => Normalmente Fechado
     parameter bit PROX_IS_PNP = 1'b1,
-    parameter bit PROX_IS_NO  = 1'b1
+    parameter bit PROX_IS_NO  = 1'b1,
+    parameter bit HOMING_USE_INDEX = 1'b1
 ) (
     input  logic clk,
     input  logic rst_n,
@@ -31,6 +32,10 @@ module motion_service #(
     input  logic [31:0]        enc_pos_x,
     input  logic [31:0]        enc_pos_y,
     input  logic [31:0]        enc_pos_z,
+    // Pulsos de índice Z por eixo
+    input  logic i_idx_pulse_x,
+    input  logic i_idx_pulse_y,
+    input  logic i_idx_pulse_z,
     // Sensores brutos por eixo
     input  logic i_prox_in_x,
     input  logic i_prox_in_y,
@@ -54,6 +59,7 @@ module motion_service #(
   import move_probe_level_request_pkg::*;
   import move_queue_status_request_pkg::*;
   import move_home_response_pkg::*;
+  import home_status_response_pkg::*;
   import move_queue_status_response_pkg::*;
   import start_move_response_pkg::*;
   import move_queue_add_response_pkg::*;
@@ -138,6 +144,14 @@ module motion_service #(
   logic        home_pending;
   logic [7:0]  home_frame_id;
   logic [2:0]  home_axis_mask;
+  logic signed [31:0] home_offset_x, home_offset_y, home_offset_z;
+  logic signed [31:0] pos_rel_x, pos_rel_y, pos_rel_z;
+  logic [2:0]  home_valid;
+  logic [2:0]  home_done_mask;
+  logic        home_status_req;
+  logic        home_start_x, home_start_y, home_start_z;
+  logic        home_active_x, home_active_y, home_active_z;
+  logic        home_done_pulse_x, home_done_pulse_y, home_done_pulse_z;
 
 `ifdef __SIM_BUILD__
   localparam bit SAFETY_ENABLE = 1'b0;
@@ -145,9 +159,12 @@ module motion_service #(
   localparam bit SAFETY_ENABLE = 1'b1;
 `endif
   // Stop/enable por eixo (E-STOP global + prox do próprio eixo)
-  assign stop_x = ((SAFETY_ENABLE ? (estop_inhibit | prox_active_x) : 1'b0) | move_end_pulse);
-  assign stop_y = ((SAFETY_ENABLE ? (estop_inhibit | prox_active_y) : 1'b0) | move_end_pulse);
-  assign stop_z = ((SAFETY_ENABLE ? (estop_inhibit | prox_active_z) : 1'b0) | move_end_pulse);
+  assign stop_x = ((SAFETY_ENABLE ? (estop_inhibit | (prox_active_x & ~home_active_x)) : 1'b0)
+                   | move_end_pulse | home_done_pulse_x);
+  assign stop_y = ((SAFETY_ENABLE ? (estop_inhibit | (prox_active_y & ~home_active_y)) : 1'b0)
+                   | move_end_pulse | home_done_pulse_y);
+  assign stop_z = ((SAFETY_ENABLE ? (estop_inhibit | (prox_active_z & ~home_active_z)) : 1'b0)
+                   | move_end_pulse | home_done_pulse_z);
 
   // Cálculo de velocidades por eixo (diferença por pid_tick)
   logic [31:0]        enc_pos_x_q, enc_pos_y_q, enc_pos_z_q;
@@ -168,9 +185,9 @@ module motion_service #(
 
   // Eixos (axis_controller_service agrega PID + driver + prox local — usa prox local)
   logic drv_enable_x, drv_enable_y, drv_enable_z;
-  assign drv_enable_x = SAFETY_ENABLE ? (tick_enable & ~estop_inhibit & ~prox_active_x) : tick_enable;
-  assign drv_enable_y = SAFETY_ENABLE ? (tick_enable & ~estop_inhibit & ~prox_active_y) : tick_enable;
-  assign drv_enable_z = SAFETY_ENABLE ? (tick_enable & ~estop_inhibit & ~prox_active_z) : tick_enable;
+  assign drv_enable_x = SAFETY_ENABLE ? (tick_enable & ~estop_inhibit & ~(prox_active_x & ~home_active_x)) : tick_enable;
+  assign drv_enable_y = SAFETY_ENABLE ? (tick_enable & ~estop_inhibit & ~(prox_active_y & ~home_active_y)) : tick_enable;
+  assign drv_enable_z = SAFETY_ENABLE ? (tick_enable & ~estop_inhibit & ~(prox_active_z & ~home_active_z)) : tick_enable;
 
   axis_controller_service u_axis_x (
     .clk(clk), .rst_n(rst_n),
@@ -200,6 +217,20 @@ module motion_service #(
     .i_enc_pos(enc_pos_z), .i_enc_vel(enc_vel_z), .i_prox_in(i_prox_in_z),
     .o_step(tmc_step_z), .o_dir(tmc_dir_z), .o_enn(tmc_enn_z), .o_busy(busy_z),
     .o_position(), .o_prox_active()
+  );
+
+  // FSM de homing por eixo
+  axis_home_service #(.HOMING_USE_INDEX(HOMING_USE_INDEX)) u_home_x (
+    .clk(clk), .rst_n(rst_n), .start(home_start_x), .prox_active(prox_active_x),
+    .idx_pulse(i_idx_pulse_x), .homing(home_active_x), .done_pulse(home_done_pulse_x)
+  );
+  axis_home_service #(.HOMING_USE_INDEX(HOMING_USE_INDEX)) u_home_y (
+    .clk(clk), .rst_n(rst_n), .start(home_start_y), .prox_active(prox_active_y),
+    .idx_pulse(i_idx_pulse_y), .homing(home_active_y), .done_pulse(home_done_pulse_y)
+  );
+  axis_home_service #(.HOMING_USE_INDEX(HOMING_USE_INDEX)) u_home_z (
+    .clk(clk), .rst_n(rst_n), .start(home_start_z), .prox_active(prox_active_z),
+    .idx_pulse(i_idx_pulse_z), .homing(home_active_z), .done_pulse(home_done_pulse_z)
   );
 
   // FSM de controle e stream de respostas -----------------------------------
@@ -240,10 +271,19 @@ module motion_service #(
       home_pending   <= 1'b0;
       home_frame_id  <= 8'd0;
       home_axis_mask <= 3'd0;
+      home_offset_x  <= '0; home_offset_y <= '0; home_offset_z <= '0;
+      pos_rel_x      <= '0; pos_rel_y    <= '0; pos_rel_z    <= '0;
+      home_valid     <= 3'b000;
+      home_done_mask <= 3'b000;
+      home_status_req<= 1'b0;
+      home_start_x   <= 1'b0; home_start_y <= 1'b0; home_start_z <= 1'b0;
     end else begin
       start_x        <= 1'b0;
       start_y        <= 1'b0;
       start_z        <= 1'b0;
+      home_start_x   <= 1'b0;
+      home_start_y   <= 1'b0;
+      home_start_z   <= 1'b0;
       sync_req       <= 1'b0;
       move_end_pulse <= 1'b0;
 
@@ -251,21 +291,61 @@ module motion_service #(
       if (SAFETY_ENABLE && estop_inhibit)
         move_enabled <= 1'b0;
 
+      // Atualiza pos_rel continuamente após homing válido
+      if (home_valid[0])
+        pos_rel_x <= $signed(enc_pos_x) - home_offset_x;
+      else
+        pos_rel_x <= 32'sd0;
+      if (home_valid[1])
+        pos_rel_y <= $signed(enc_pos_y) - home_offset_y;
+      else
+        pos_rel_y <= 32'sd0;
+      if (home_valid[2])
+        pos_rel_z <= $signed(enc_pos_z) - home_offset_z;
+      else
+        pos_rel_z <= 32'sd0;
+
+      // Captura offsets ao concluir homing por eixo
+      if (home_done_pulse_x) begin
+        home_offset_x  <= enc_pos_x;
+        pos_rel_x      <= 32'sd0;
+        home_valid[0]  <= 1'b1;
+        home_done_mask[0] <= 1'b1;
+        cont_x         <= 1'b0;
+      end
+      if (home_done_pulse_y) begin
+        home_offset_y  <= enc_pos_y;
+        pos_rel_y      <= 32'sd0;
+        home_valid[1]  <= 1'b1;
+        home_done_mask[1] <= 1'b1;
+        cont_y         <= 1'b0;
+      end
+      if (home_done_pulse_z) begin
+        home_offset_z  <= enc_pos_z;
+        pos_rel_z      <= 32'sd0;
+        home_valid[2]  <= 1'b1;
+        home_done_mask[2] <= 1'b1;
+        cont_z         <= 1'b0;
+      end
+
       // Emite starts alinhados ao próximo tick
       if (sync_start && (start_pending != 3'b000)) begin
         start_x       <= start_pending[0];
         start_y       <= start_pending[1];
         start_z       <= start_pending[2];
+        home_start_x  <= start_pending[0];
+        home_start_y  <= start_pending[1];
+        home_start_z  <= start_pending[2];
         start_pending <= 3'b000;
       end
 
-      // Resposta de homing quando sensor(es) do(s) eixo(s) requisitado(s) acionam
-      if (home_pending && (|(prox_mask & home_axis_mask)) && !pending) begin
+      // Resposta de homing quando todos os eixos requisitados finalizam
+      if (home_pending && (home_done_mask == home_axis_mask) && !pending) begin
         move_home_resp_bytes_t r;
         r = move_home_response_pkg::make_default();
         r.frameIdEcho  = home_frame_id;
         r.status       = 8'd0; // ALL_OK
-        r.axisHomeMask = {5'b0, (prox_mask & home_axis_mask)};
+        r.axisHomeMask = {5'b0, home_done_mask};
         r.errorFlags   = 8'd0;
         r = move_home_response_pkg::set_parity(r);
         pend_bits <= '0;
@@ -273,10 +353,29 @@ module motion_service #(
                   <= move_home_response_pkg::encoder(r);
         pend_len  <= move_home_response_pkg::FRAME_BITS/8;
         pending   <= 1'b1;
-        home_pending <= 1'b0;
-        cont_x <= 1'b0;
-        cont_y <= 1'b0;
-        cont_z <= 1'b0;
+        home_pending   <= 1'b0;
+        home_status_req<= 1'b1;
+      end
+
+      // Envia HOME_STATUS se requisitado
+      if (home_status_req && !pending) begin
+        home_status_resp_bytes_t hs;
+        hs = home_status_response_pkg::make_default();
+        hs.frameIdEcho = home_frame_id;
+        hs.axisMask    = {5'b0, home_valid};
+        hs.posRelX     = pos_rel_x[15:0];
+        hs.homeOffX    = home_offset_x[15:0];
+        hs.posRelY     = pos_rel_y[15:0];
+        hs.homeOffY    = home_offset_y[15:0];
+        hs.posRelZ     = pos_rel_z[15:0];
+        hs.homeOffZ    = home_offset_z[15:0];
+        hs = home_status_response_pkg::set_parity(hs);
+        pend_bits <= '0;
+        pend_bits[SHIFT_BITS-1 -: home_status_response_pkg::FRAME_BITS]
+                  <= home_status_response_pkg::encoder(hs);
+        pend_len  <= home_status_response_pkg::FRAME_BITS/8;
+        pending   <= 1'b1;
+        home_status_req <= 1'b0;
       end
 
       if (frame_valid) begin
@@ -352,6 +451,7 @@ module motion_service #(
               home_pending     <= |move_home_frame.axisMask[2:0];
               home_frame_id    <= move_home_frame.frameId;
               home_axis_mask   <= move_home_frame.axisMask[2:0];
+              home_done_mask   <= 3'b000;
             end else begin
               move_home_resp_bytes_t r;
               r = move_home_response_pkg::make_default();
@@ -379,6 +479,10 @@ module motion_service #(
                       <= move_queue_status_response_pkg::encoder(r);
             pend_len  <= 12;
             pending   <= 1'b1;
+            if (home_valid != 3'b111) begin
+              home_status_req <= 1'b1;
+              home_frame_id   <= queue_status_frame.frameId;
+            end
           end
           MOVE_END_TYPE: begin
             move_end_resp_bytes_t r;

--- a/src/services/motion/motion_service.sv
+++ b/src/services/motion/motion_service.sv
@@ -468,7 +468,8 @@ module motion_service #(
           MOVE_QUEUE_STATUS_TYPE: begin
             move_queue_status_resp_bytes_t r;
             r = move_queue_status_response_pkg::make_default();
-            r.frameIdEcho = current_move_id;
+            // ecoa o frameId do pedido de status, não o último MOVE
+            r.frameIdEcho = queue_status_frame.frameId;
             r.status      = (busy_x | busy_y | busy_z) ? 8'd0 : 8'd1; // Running/Idle
             r.pidErrX     = 8'd0;
             r.pidErrY     = 8'd0;

--- a/src/top.sv
+++ b/src/top.sv
@@ -424,7 +424,8 @@ module top (
     // -------------------------
     motion_service #(
       .PROX_IS_PNP(1'b0), // NPN
-      .PROX_IS_NO (1'b1)  // Normalmente Aberto (ajuste para 1'b0 se for NC)
+      .PROX_IS_NO (1'b1),  // Normalmente Aberto (ajuste para 1'b0 se for NC)
+      .HOMING_USE_INDEX(1'b1)
     ) u_motion (
       .clk                 (i_clk),
       .rst_n               (i_resetn),
@@ -439,6 +440,9 @@ module top (
       .enc_pos_x           (enc_position),
       .enc_pos_y           (enc_position_y),
       .enc_pos_z           (enc_position_z),
+      .i_idx_pulse_x       (enc_z_pulse),
+      .i_idx_pulse_y       (enc_z_pulse_y),
+      .i_idx_pulse_z       (enc_z_pulse_z),
       .i_prox_in_x         (i_prox_in_x),
       .i_prox_in_y         (i_prox_in_y),
       .i_prox_in_z         (i_prox_in_z),

--- a/tb/tests/framings_tb.sv
+++ b/tb/tests/framings_tb.sv
@@ -228,6 +228,24 @@ module framings_tb;
     $display("Sucesso: test_move_queue_add_response");
   endtask
 
+  task automatic test_home_status_response();
+    home_status_response_pkg::home_status_resp_bytes_t r;
+    logic [home_status_response_pkg::FRAME_BITS-1:0] raw;
+    home_status_response_pkg::home_status_resp_bytes_t d;
+    r = home_status_response_pkg::make_default();
+    r.frameIdEcho = 8'h70;
+    r.axisMask    = 8'h07;
+    r.posRelX     = 16'h0001; r.homeOffX = 16'h0002;
+    r.posRelY     = 16'h0003; r.homeOffY = 16'h0004;
+    r.posRelZ     = 16'h0005; r.homeOffZ = 16'h0006;
+    r = home_status_response_pkg::set_parity(r);
+    `TEST_ASSERT(home_status_response_pkg::check_parity(r), "test_home_status_response");
+    raw = home_status_response_pkg::encoder(r);
+    d   = home_status_response_pkg::decoder(raw);
+    `TEST_ASSERT(d == r, "test_home_status_response");
+    $display("Sucesso: test_home_status_response");
+  endtask
+
   task automatic test_move_probe_level_response();
     move_probe_level_response_pkg::move_probe_level_resp_bytes_t r;
     logic [159:0] raw;
@@ -279,6 +297,7 @@ module framings_tb;
     test_fpga_status_response();
     test_move_queue_add_response();
     test_move_probe_level_response();
+    test_home_status_response();
     test_led_ctrl_response();
     $display("All framing tests passed");
     $finish;

--- a/tb/tests/spi_full_flow_motion_10_moves_tb.sv
+++ b/tb/tests/spi_full_flow_motion_10_moves_tb.sv
@@ -101,10 +101,12 @@ module spi_full_flow_motion_10_moves_tb;
     .move_end_frame(move_end_frame),
     .move_home_frame('0), .probe_frame('0), .queue_status_frame('0),
     .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0),
+    .i_idx_pulse_x(1'b0), .i_idx_pulse_y(1'b0), .i_idx_pulse_z(1'b0),
     .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
 

--- a/tb/tests/spi_full_flow_motion_basic_tb.sv
+++ b/tb/tests/spi_full_flow_motion_basic_tb.sv
@@ -331,6 +331,12 @@ module spi_full_flow_motion_basic_tb;
     // 5) MOVE_QUEUE_STATUS (agora deve indicar Idle)
     send_move_queue_status(8'h13);
 
+    // Aguarda envio da resposta e HOME_STATUS antes de encerrar
+    cycles = 0;
+    while (resp_byte_count < 70 && cycles < 2000) begin
+      @(posedge clk); cycles++;
+    end
+
     // 6) MOVE_END encerra sessão (desabilita ENN)
     send_move_end(8'h14);
 
@@ -339,7 +345,7 @@ module spi_full_flow_motion_basic_tb;
     // + (12+18) para cada MOVE_QUEUE_STATUS seguido de HOME_STATUS
     // + 4 (MOVE_END) = 74 bytes
     cycles = 0;
-    while (resp_byte_count < 74 && cycles < 2000) begin
+    while (resp_byte_count < 74 && cycles < 4000) begin
       @(posedge clk); cycles++;
     end
     `TEST_ASSERT(resp_byte_count >= 74, "timeout_respostas")

--- a/tb/tests/spi_full_flow_motion_basic_tb.sv
+++ b/tb/tests/spi_full_flow_motion_basic_tb.sv
@@ -13,6 +13,7 @@ module spi_full_flow_motion_basic_tb;
   import move_queue_add_response_pkg::*;
   import move_queue_status_request_pkg::*;
   import move_queue_status_response_pkg::*;
+  import home_status_response_pkg::*;
   import move_end_request_pkg::*;
   import move_end_response_pkg::*;
 
@@ -132,7 +133,8 @@ module spi_full_flow_motion_basic_tb;
   );
 
   // Captura de bytes de resposta
-  localparam int RESP_CAP_BYTES = 64;
+  // buffer grande o suficiente para incluir HOME_STATUS extras
+  localparam int RESP_CAP_BYTES = 96;
   spi_service_pkg::byte_t resp_bytes[RESP_CAP_BYTES];
   int unsigned resp_byte_count;
 
@@ -258,6 +260,16 @@ module spi_full_flow_motion_basic_tb;
     `TEST_ASSERT(dec.status == exp_status, "mqs_status")
   endtask
 
+  task automatic check_home_status_resp_at(input int start_idx, input spi_service_pkg::byte_t exp_axis_mask);
+    logic [143:0] raw;
+    home_status_resp_bytes_t dec;
+    for (int i = 0; i < 18; i++) raw[143 - i*8 -: 8] = resp_bytes[start_idx + i];
+    dec = home_status_response_pkg::decoder(raw);
+    `TEST_ASSERT(home_status_response_pkg::check_parity(dec), "hs_parity")
+    `TEST_ASSERT(dec.msgType == protocol_constants_pkg::HOME_STATUS_TYPE, "hs_type")
+    `TEST_ASSERT(dec.axisMask == {5'b0, exp_axis_mask}, "hs_axis_mask")
+  endtask
+
   task automatic check_move_end_resp_at(input int start_idx, input spi_service_pkg::byte_t frameId);
     logic [31:0] raw;
     move_end_resp_bytes_t dec;
@@ -322,19 +334,24 @@ module spi_full_flow_motion_basic_tb;
     // 6) MOVE_END encerra sessão (desabilita ENN)
     send_move_end(8'h14);
 
-    // Aguarda bytes chegarem: 4 + 6 + 12 + 12 + 4 = 38 bytes
+    // Aguarda bytes chegarem:
+    // 4 (START_MOVE) + 6 (MOVE_QUEUE_ADD)
+    // + (12+18) para cada MOVE_QUEUE_STATUS seguido de HOME_STATUS
+    // + 4 (MOVE_END) = 74 bytes
     cycles = 0;
-    while (resp_byte_count < 38 && cycles < 2000) begin
+    while (resp_byte_count < 74 && cycles < 2000) begin
       @(posedge clk); cycles++;
     end
-    `TEST_ASSERT(resp_byte_count >= 38, "timeout_respostas")
+    `TEST_ASSERT(resp_byte_count >= 74, "timeout_respostas")
 
     // Decodifica e checa respostas
     idx = 0;
     check_start_move_resp_at(idx, 8'h10); idx += 4;
     check_move_queue_add_resp_at(idx, 8'h11, 8'h00); idx += 6;
     check_move_queue_status_resp_at(idx, 8'h00); idx += 12; // Running
+    check_home_status_resp_at(idx, 8'h00);      idx += 18;
     check_move_queue_status_resp_at(idx, 8'h01); idx += 12; // Idle
+    check_home_status_resp_at(idx, 8'h00);      idx += 18;
     check_move_end_resp_at(idx, 8'h14); idx += 4;
 
     // ENN deve ter sido desativado após MOVE_END (ativo-baixo)

--- a/tb/tests/spi_full_flow_motion_basic_tb.sv
+++ b/tb/tests/spi_full_flow_motion_basic_tb.sv
@@ -102,11 +102,13 @@ module spi_full_flow_motion_basic_tb;
     .probe_frame('0),
     .queue_status_frame(queue_status_frame),
     .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0),
+    .i_idx_pulse_x(1'b0), .i_idx_pulse_y(1'b0), .i_idx_pulse_z(1'b0),
     .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0),
     .i_estop_in(estop_in),
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
 

--- a/tb/tests/spi_full_flow_motion_early_end_tb.sv
+++ b/tb/tests/spi_full_flow_motion_early_end_tb.sv
@@ -52,10 +52,13 @@ module spi_full_flow_motion_early_end_tb;
     .clk(clk), .rst_n(rst_n), .frame_valid(frame_valid), .msgType(out_msgType),
     .start_move_frame(start_move_frame), .queue_add_frame(queue_add_frame),
     .move_end_frame(move_end_frame), .move_home_frame('0), .probe_frame('0), .queue_status_frame('0),
-    .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0), .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
+    .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0),
+    .i_idx_pulse_x(1'b0), .i_idx_pulse_y(1'b0), .i_idx_pulse_z(1'b0),
+    .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
   assign streams[0].valid = motion_stream.valid;

--- a/tb/tests/spi_full_flow_motion_home_tb.sv
+++ b/tb/tests/spi_full_flow_motion_home_tb.sv
@@ -11,6 +11,7 @@ module spi_full_flow_motion_home_tb;
   import start_move_response_pkg::*;
   import move_home_request_pkg::*;
   import move_home_response_pkg::*;
+  import home_status_response_pkg::*;
 
   // Dump de ondas para inspeção (Verilator)
 `ifdef VERILATOR
@@ -47,6 +48,7 @@ module spi_full_flow_motion_home_tb;
   logic [31:0] enc_pos;
   logic signed [31:0] enc_vel;
   logic prox_in, estop_in;
+  logic idx_pulse;
   logic tmc_step_x, tmc_dir_x, tmc_enn_x;
   logic tmc_step_y, tmc_dir_y, tmc_enn_y;
   logic tmc_step_z, tmc_dir_z, tmc_enn_z;
@@ -93,7 +95,7 @@ module spi_full_flow_motion_home_tb;
     .led_ctrl_frame()
   );
 
-  motion_service u_motion(
+  motion_service #(.HOMING_USE_INDEX(1)) u_motion(
     .clk(clk), .rst_n(rst_n),
     .frame_valid(frame_valid),
     .msgType(out_msgType),
@@ -104,11 +106,13 @@ module spi_full_flow_motion_home_tb;
     .probe_frame('0),
     .queue_status_frame('0),
     .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0),
+    .i_idx_pulse_x(idx_pulse), .i_idx_pulse_y(1'b0), .i_idx_pulse_z(1'b0),
     .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0),
     .i_estop_in(estop_in),
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
 
@@ -210,6 +214,18 @@ module spi_full_flow_motion_home_tb;
     `TEST_ASSERT(dec.axisHomeMask[2:0] == axisMask[2:0], "mh_axis_mask")
   endtask
 
+  task automatic check_home_status_resp_at(input int start_idx, input spi_service_pkg::byte_t frameId, input spi_service_pkg::byte_t axisMask);
+    logic [home_status_response_pkg::FRAME_BITS-1:0] raw;
+    home_status_resp_bytes_t dec;
+    for (int i = 0; i < 18; i++) raw[home_status_response_pkg::FRAME_BITS-1 - i*8 -:8] = resp_bytes[start_idx + i];
+    dec = home_status_response_pkg::decoder(raw);
+    `TEST_ASSERT(home_status_response_pkg::check_parity(dec), "hs_parity");
+    `TEST_ASSERT(dec.msgType == protocol_constants_pkg::HOME_STATUS_TYPE, "hs_type");
+    `TEST_ASSERT(dec.frameIdEcho == frameId, "hs_echo");
+    `TEST_ASSERT(dec.axisMask[2:0] == axisMask[2:0], "hs_axis");
+    `TEST_ASSERT(dec.posRelX == 16'd0, "hs_posrel0");
+  endtask
+
   // Contagem de passos (X)
   int step_count_x;
   logic prev_step_x;
@@ -234,6 +250,7 @@ module spi_full_flow_motion_home_tb;
     // Portanto, o nível "seguro" (não acionado) é 0, e 1 aciona o sensor.
     prox_in = 1'b0; // PROX seguro (não acionado)
     estop_in = 1'b1; // E-STOP NC seguro
+    idx_pulse = 1'b0;
     // Resets performed in always_ff blocks
 
     repeat (4) @(posedge clk);
@@ -254,20 +271,28 @@ module spi_full_flow_motion_home_tb;
     end
     `TEST_ASSERT(step_count_x >= 5, "timeout_steps_home_start")
 
-    // Dispara sensor de proximidade (ativo-alto) -> deve gerar resposta MOVE_HOME
+    // Dispara sensor de proximidade (ativo-alto)
     prox_in = 1'b1;
 
-    // Espera bytes: 4 (start_move) + 8 (move_home resp) = 12
+    // Aguarda alguns passos adicionais e emite pulso de índice
     cycles = 0;
-    while (resp_byte_count < 12 && cycles < 2000) begin
+    while (step_count_x < 10 && cycles < 500000) begin
       @(posedge clk); cycles++;
     end
-    `TEST_ASSERT(resp_byte_count >= 12, "timeout_home_resp")
+    idx_pulse = 1'b1; @(posedge clk); idx_pulse = 1'b0;
+
+    // Espera bytes: 4 (start_move) + 8 (move_home resp) + 18 (home_status) = 30
+    cycles = 0;
+    while (resp_byte_count < 30 && cycles < 5000) begin
+      @(posedge clk); cycles++;
+    end
+    `TEST_ASSERT(resp_byte_count >= 30, "timeout_home_resp")
 
     // Checa respostas
     idx = 0;
     check_start_move_resp_at(idx, 8'h20); idx += 4;
     check_move_home_resp_at(idx, 8'h21, 8'b0000_0001); idx += 8;
+    check_home_status_resp_at(idx, 8'h21, 8'b0000_0001); idx += 18;
 
     // Após homing completo, movimento contínuo deve parar (contadores estabilizam)
     prev_cnt = step_count_x;

--- a/tb/tests/spi_full_flow_motion_multiaxis_tb.sv
+++ b/tb/tests/spi_full_flow_motion_multiaxis_tb.sv
@@ -57,10 +57,13 @@ module spi_full_flow_motion_multiaxis_tb;
     .clk(clk), .rst_n(rst_n), .frame_valid(frame_valid), .msgType(out_msgType),
     .start_move_frame(start_move_frame), .queue_add_frame(queue_add_frame),
     .move_end_frame('0), .move_home_frame('0), .probe_frame('0), .queue_status_frame('0),
-    .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0), .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
+    .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0),
+    .i_idx_pulse_x(1'b0), .i_idx_pulse_y(1'b0), .i_idx_pulse_z(1'b0),
+    .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
   assign streams[0].valid = motion_stream.valid;

--- a/tb/tests/spi_full_flow_tick_count_tb.sv
+++ b/tb/tests/spi_full_flow_tick_count_tb.sv
@@ -54,10 +54,13 @@ module spi_full_flow_tick_count_tb;
     .clk(clk), .rst_n(rst_n), .frame_valid(frame_valid), .msgType(out_msgType),
     .start_move_frame(start_move_frame), .queue_add_frame(queue_add_frame),
     .move_end_frame('0), .move_home_frame('0), .probe_frame('0), .queue_status_frame(queue_status_frame),
-    .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0), .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
+    .enc_pos_x(enc_pos), .enc_pos_y(32'd0), .enc_pos_z(32'd0),
+    .i_idx_pulse_x(1'b0), .i_idx_pulse_y(1'b0), .i_idx_pulse_z(1'b0),
+    .i_prox_in_x(prox_in), .i_prox_in_y(1'b0), .i_prox_in_z(1'b0), .i_estop_in(estop_in),
     .tmc_step_x(tmc_step_x), .tmc_dir_x(tmc_dir_x), .tmc_enn_x(tmc_enn_x),
     .tmc_step_y(tmc_step_y), .tmc_dir_y(tmc_dir_y), .tmc_enn_y(tmc_enn_y),
     .tmc_step_z(tmc_step_z), .tmc_dir_z(tmc_dir_z), .tmc_enn_z(tmc_enn_z),
+    .o_moving(),
     .tx_stream(motion_stream)
   );
   assign streams[0].valid = motion_stream.valid;

--- a/tb/tests/spi_move_queue_status_type_tb.sv
+++ b/tb/tests/spi_move_queue_status_type_tb.sv
@@ -1,0 +1,17 @@
+`timescale 1ns/1ps
+`include "lib/test_macros.svh"
+
+module spi_move_queue_status_type_tb;
+  import protocol_constants_pkg::*;
+  import move_queue_status_response_pkg::*;
+
+  initial begin
+    move_queue_status_resp_bytes_t r;
+    r = move_queue_status_response_pkg::make_default();
+    if (r.msgType != MOVE_QUEUE_STATUS_TYPE)
+      $display("Falha: mqs_type_pkg");
+    else
+      $display("Sucesso: spi_move_queue_status_type_tb");
+    $finish;
+  end
+endmodule

--- a/tb/tests/spi_rx_mosi_busy_limit_tb.sv
+++ b/tb/tests/spi_rx_mosi_busy_limit_tb.sv
@@ -1,10 +1,8 @@
 `timescale 1ns/1ps
 `include "lib/test_macros.svh"
 
-module spi_rx_mosi_flow_tb;
+module spi_rx_mosi_busy_limit_tb;
   import spi_service_pkg::*;
-
-  // FIFO com profundidade padrão para testar sinal de ocupação
   spi_fifo_if fifo();
 
   logic clk = 0;
@@ -15,8 +13,7 @@ module spi_rx_mosi_flow_tb;
   logic slave_busy;
 
   spi_rx_mosi_service dut(
-    .clk(clk),
-    .rst_n(rst_n),
+    .clk(clk), .rst_n(rst_n),
     .spi_byte_valid(spi_byte_valid),
     .spi_byte(spi_byte),
     .fifo(fifo),
@@ -24,28 +21,24 @@ module spi_rx_mosi_flow_tb;
     .slave_busy(slave_busy)
   );
 
-  // Geração de clock
   always #5 clk = ~clk;
 
   initial begin
     spi_byte_valid = 0;
     spi_byte       = 0;
+    repeat (2) @(posedge clk);
+    rst_n = 1;
 
-    #12 rst_n = 1;
-
-    // Envia RX_BLOCK_LEVEL+1 bytes: busy deve ativar após exceder limite
+    // Envia RX_BLOCK_LEVEL+1 bytes para exceder o limite
     for (int i = 0; i < RX_BLOCK_LEVEL + 1; i++) begin
-      send_byte(8'h00);
+      send_byte(8'hFF);
     end
     @(posedge clk);
-    @(posedge clk);
-    $display("count=%0d busy=%0b", fifo.count, slave_busy);
-    if (!slave_busy) begin
-      $display("Falha: busy_apos_limite");
-      $finish;
-    end
-
-    $display("Sucesso: spi_rx_mosi_flow_tb");
+    $display("Contagem=%0d busy=%0b", fifo.count, slave_busy);
+    if (fifo.count != RX_BLOCK_LEVEL + 1 || !slave_busy)
+      $display("Falha: busy_limite_sub");
+    else
+      $display("Sucesso: spi_rx_mosi_busy_limit_tb");
     $finish;
   end
 

--- a/tb/tests/spi_rx_mosi_flow_tb.sv
+++ b/tb/tests/spi_rx_mosi_flow_tb.sv
@@ -31,7 +31,8 @@ module spi_rx_mosi_flow_tb;
     spi_byte_valid = 0;
     spi_byte       = 0;
 
-    #12 rst_n = 1;
+    repeat (2) @(posedge clk);
+    rst_n = 1;
 
     // Envia RX_BLOCK_LEVEL+1 bytes: busy deve ativar após exceder limite
     for (int i = 0; i < RX_BLOCK_LEVEL + 1; i++) begin
@@ -40,12 +41,10 @@ module spi_rx_mosi_flow_tb;
     @(posedge clk);
     @(posedge clk);
     $display("count=%0d busy=%0b", fifo.count, slave_busy);
-    if (!slave_busy) begin
+    if (!slave_busy)
       $display("Falha: busy_apos_limite");
-      $finish;
-    end
-
-    $display("Sucesso: spi_rx_mosi_flow_tb");
+    else
+      $display("Sucesso: spi_rx_mosi_flow_tb");
     $finish;
   end
 

--- a/tb/tests/spi_tx_hub_rr_tb.sv
+++ b/tb/tests/spi_tx_hub_rr_tb.sv
@@ -1,0 +1,96 @@
+`timescale 1ns/1ps
+`include "lib/test_macros.svh"
+
+module spi_tx_hub_rr_tb;
+  import spi_service_pkg::*;
+  import start_move_response_pkg::*;
+
+  logic clk = 0;
+  logic rst_n = 0;
+  always #5 clk = ~clk;
+
+  spi_fifo_if #(.DEPTH(TX_FIFO_DEPTH), .DROP_OLD_ON_FULL(1)) tx_fifo();
+  resp_stream_if streams[2]();
+  logic tx_busy;
+
+  spi_tx_hub_service #(.NUM_STREAMS(2)) dut(
+    .clk(clk), .rst_n(rst_n),
+    .streams(streams),
+    .tx_fifo(tx_fifo),
+    .tx_busy(tx_busy)
+  );
+
+  task automatic wait_tx_bytes(input int n, input int max_cycles=200);
+    int cycles = 0;
+    while (tx_fifo.count < n && cycles < max_cycles) begin
+      @(posedge clk); cycles++;
+    end
+    `TEST_ASSERT(tx_fifo.count >= n, "tx_fifo_timeout")
+  endtask
+
+  task automatic publish_on_stream(
+      input int i,
+      input logic [RESP_MAX_BYTES*8-1:0] bits,
+      input int unsigned len_bytes
+  );
+    case (i)
+      0: begin
+        streams[0].bits  = bits;
+        streams[0].len   = len_bytes;
+        streams[0].valid = 1'b1;
+        do @(posedge clk); while (streams[0].ready !== 1'b1);
+        @(posedge clk);
+        streams[0].valid = 1'b0;
+      end
+      1: begin
+        streams[1].bits  = bits;
+        streams[1].len   = len_bytes;
+        streams[1].valid = 1'b1;
+        do @(posedge clk); while (streams[1].ready !== 1'b1);
+        @(posedge clk);
+        streams[1].valid = 1'b0;
+      end
+      default: begin end
+    endcase
+  endtask
+
+  start_move_resp_bytes_t sm;
+  logic [31:0] raw_sm;
+  logic [RESP_MAX_BYTES*8-1:0] bits0, bits1;
+
+  initial begin
+    streams[0].valid = 0; streams[0].bits = '0; streams[0].len = '0;
+    streams[1].valid = 0; streams[1].bits = '0; streams[1].len = '0;
+
+    repeat (2) @(posedge clk);
+    rst_n = 1;
+
+    sm = start_move_response_pkg::make_default();
+    sm.frameIdEcho = 8'h11;
+    bits0 = '0; bits0[RESP_MAX_BYTES*8-1 -: 32] = start_move_response_pkg::encoder(sm);
+    sm.frameIdEcho = 8'h22;
+    bits1 = '0; bits1[RESP_MAX_BYTES*8-1 -: 32] = start_move_response_pkg::encoder(sm);
+
+    fork
+      publish_on_stream(0, bits0, 4);
+      publish_on_stream(1, bits1, 4);
+    join
+
+    wait_tx_bytes(8, 200);
+
+    // lê primeiro frame
+    for (int i = 0; i < 4; i++) begin
+      byte_t b; tx_fifo.read(b); raw_sm[31 - i*8 -: 8] = b; end
+    sm = start_move_response_pkg::decoder(raw_sm);
+    `TEST_ASSERT(sm.frameIdEcho == 8'h11 || sm.frameIdEcho == 8'h22, "rr_first_any")
+
+    // lê segundo frame
+    for (int i = 0; i < 4; i++) begin
+      byte_t b; tx_fifo.read(b); raw_sm[31 - i*8 -: 8] = b; end
+    sm = start_move_response_pkg::decoder(raw_sm);
+    `TEST_ASSERT(sm.frameIdEcho == 8'h11 || sm.frameIdEcho == 8'h22, "rr_second_any")
+
+    $display("Sucesso: spi_tx_hub_rr_tb");
+    $finish;
+  end
+endmodule

--- a/tb/tests/spi_tx_hub_service_tb.sv
+++ b/tb/tests/spi_tx_hub_service_tb.sv
@@ -160,6 +160,13 @@ module spi_tx_hub_service_tb;
     rst_n = 1;
 
     test_led_only();
+
+    // Reseta HUB e FIFO antes do teste de round-robin
+    rst_n = 0;
+    tx_fifo.wr_ptr = 0; tx_fifo.rd_ptr = 0; tx_fifo.count = 0;
+    repeat (2) @(posedge clk);
+    rst_n = 1;
+
     test_round_robin_two_streams();
 
     $display("Sucesso: spi_tx_hub_service_tb");

--- a/tb/verilator/run_verilator_framings_tests.py
+++ b/tb/verilator/run_verilator_framings_tests.py
@@ -63,10 +63,16 @@ expected = [
     "test_fpga_status_response",
     "test_move_queue_add_response",
     "test_move_probe_level_response",
+    "test_home_status_response",
 ]
 
 for name in expected:
-    if f"Sucesso: {name}" not in proc.stdout:
+    expected_str = f"Sucesso: {name}"
+    print(f"Esperado: {expected_str}")
+    if expected_str in proc.stdout:
+        print(f"Recebido: {expected_str}")
+    else:
+        print(f"Recebido: {proc.stdout.strip()}")
         print(f"Falha: {name}")
         sys.exit(1)
 

--- a/tb/verilator/run_verilator_parser_tests.py
+++ b/tb/verilator/run_verilator_parser_tests.py
@@ -61,8 +61,12 @@ for tb in tb_files:
 
     proc = subprocess.run([str(obj_dir / f"V{top}")], cwd=root, capture_output=True, text=True)
     print(proc.stdout)
-    if proc.returncode != 0 or "Sucesso" not in proc.stdout:
+    expected_str = "Sucesso"
+    print(f"Esperado: saída contendo '{expected_str}'")
+    print(f"Recebido: {proc.stdout.strip()}")
+    if proc.returncode != 0 or expected_str not in proc.stdout:
         print(proc.stderr)
+        print(f"Falha: {top}")
         success = False
         break
 

--- a/tb/verilator/run_verilator_parser_tests.py
+++ b/tb/verilator/run_verilator_parser_tests.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 import sys
 import shutil
+import argparse
 
 root = Path(__file__).resolve().parents[2]
 temp_dir = root / "tb" / "tests" / "temp"
@@ -14,8 +15,22 @@ router_root = root / "src" / "protocol" / "routers"
 
 tb_dir = root / "tb" / "tests"
 
+# permite selecionar subconjuntos de testes pela linha de comando
+argp = argparse.ArgumentParser()
+argp.add_argument("tests", nargs="*", help="executa apenas os testbenches cujos nomes contêm estas strings")
+argp.add_argument("--list", action="store_true", help="lista os testbenches disponíveis e sai")
+args = argp.parse_args()
+
 tb_files = sorted(tb_dir.glob("*_request_parser_tb.sv"))
 tb_files.append(tb_dir / "request_router_tb.sv")
+
+if args.list:
+    for tb in tb_files:
+        print(tb.stem)
+    sys.exit(0)
+
+if args.tests:
+    tb_files = [tb for tb in tb_files if any(t in tb.stem for t in args.tests)]
 
 files = []
 files.extend(sorted((framing_root / "constants").glob("*.sv")))
@@ -35,6 +50,7 @@ for tb in tb_files:
     obj_dir.mkdir(parents=True, exist_ok=True)
 
     top = tb.stem
+    print(f"Compilando e executando {top}...")
     # Garante que o Verilator está disponível
     if shutil.which("verilator") is None:
         print("Verilator não encontrado no PATH. Instale-o ou use ModelSim (vsim).")

--- a/tb/verilator/run_verilator_service_tests.py
+++ b/tb/verilator/run_verilator_service_tests.py
@@ -93,8 +93,12 @@ for tb in tb_files:
 
     proc = subprocess.run([str(obj_dir / f"V{top}")], cwd=root, capture_output=True, text=True)
     print(proc.stdout)
-    if proc.returncode != 0 or "Sucesso" not in proc.stdout:
+    expected_str = "Sucesso"
+    print(f"Esperado: saída contendo '{expected_str}' para {top}")
+    print(f"Recebido: {proc.stdout.strip()}")
+    if proc.returncode != 0 or expected_str not in proc.stdout:
         print(proc.stderr)
+        print(f"Falha: {top}")
         success = False
         break
 

--- a/tb/verilator/run_verilator_service_tests.py
+++ b/tb/verilator/run_verilator_service_tests.py
@@ -3,6 +3,7 @@ import subprocess
 import shutil
 from pathlib import Path
 import sys
+import argparse
 
 root = Path(__file__).resolve().parents[2]
 temp_dir = root / "tb" / "tests" / "temp"
@@ -22,10 +23,13 @@ tb_dir = root / "tb" / "tests"
 tb_files = [
     tb_dir / "spi_rx_mosi_service_tb.sv",
     tb_dir / "spi_rx_mosi_flow_tb.sv",
+    tb_dir / "spi_rx_mosi_busy_limit_tb.sv",
     tb_dir / "spi_rx_hub_service_tb.sv",
     tb_dir / "spi_tx_buffer_tb.sv",
     tb_dir / "spi_full_flow_led_20_tb.sv",
     tb_dir / "spi_tx_hub_service_tb.sv",
+    tb_dir / "spi_tx_hub_rr_tb.sv",
+    tb_dir / "spi_move_queue_status_type_tb.sv",
     # Motion end-to-end tests (SPI -> tick -> STEP)
     tb_dir / "spi_full_flow_motion_basic_tb.sv",
     tb_dir / "spi_full_flow_motion_home_tb.sv",
@@ -33,6 +37,20 @@ tb_files = [
     tb_dir / "spi_full_flow_motion_early_end_tb.sv",
     tb_dir / "spi_full_flow_motion_10_moves_tb.sv",
 ]
+
+parser = argparse.ArgumentParser()
+parser.add_argument("tests", nargs="*", help="lista de testbenches a executar")
+parser.add_argument("--list", action="store_true", dest="list_tests", help="lista testbenches disponíveis")
+args = parser.parse_args()
+
+if args.list_tests:
+    for tb in tb_files:
+        print(tb.stem)
+    sys.exit(0)
+
+if args.tests:
+    stems = set(args.tests)
+    tb_files = [tb for tb in tb_files if tb.stem in stems]
 
 files = []
 files.extend(sorted((framing_root / "constants").glob("*.sv")))


### PR DESCRIPTION
## Summary
- add per-axis homing FSM and indexed homing support
- track and report home offsets and relative positions
- provide new HOME_STATUS response and accompanying tests
- print expected vs received results in all Verilator test runners for clearer diagnostics

## Testing
- `python tb/verilator/run_verilator_framings_tests.py`
- `python tb/verilator/run_verilator_parser_tests.py`
- `python tb/verilator/run_verilator_service_tests.py` *(fails: busy_apos_limite, rr_first_any, mqs_type)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf5c1f64c832695599e15c4e8bcca