### PR TITLE
Add active-low support to LED service

### DIFF
--- a/src/services/led/led_service.sv
+++ b/src/services/led/led_service.sv
@@ -7,7 +7,9 @@
 // -----------------------------------------------------------------------------
 `ifndef LED_SERVICE_SV
 `define LED_SERVICE_SV
-module led_service (
+module led_service #(
+    parameter bit ACTIVE_LOW = 0
+) (
     input  logic clk,
     input  logic rst_n,
     input  logic frame_valid,
@@ -34,7 +36,7 @@ module led_service (
   // Registradores de saída
   always_ff @(posedge clk or negedge rst_n) begin
     if (!rst_n) begin
-      leds_r     <= 6'b0;
+      leds_r     <= ACTIVE_LOW ? 6'b111111 : 6'b0;
       resp_valid <= 1'b0;
       resp_frame <= led_control_response_pkg::make_default();
       pending    <= 1'b0;
@@ -55,7 +57,7 @@ module led_service (
           // bits fora do intervalo 0..5 -> erro
           r.status = 8'h01; // LED inexistente
         end else begin
-          if (led_req.ledValue[0])
+          if (ACTIVE_LOW ? ~led_req.ledValue[0] : led_req.ledValue[0])
             leds_r <= leds_r | led_req.ledMask[5:0];
           else
             leds_r <= leds_r & ~led_req.ledMask[5:0];

--- a/src/top.sv
+++ b/src/top.sv
@@ -232,7 +232,7 @@ module top (
     resp_stream_if led_stream();
     wire                        led_resp_valid;
     led_control_response_pkg::led_ctrl_resp_bytes_t led_resp_frame;
-    led_service u_led_synth (
+    led_service #(.ACTIVE_LOW(1)) u_led_synth (
       .clk        (i_clk),
       .rst_n      (i_resetn),
       .frame_valid(frame_valid),

--- a/tb/tests/led_service_tb.sv
+++ b/tb/tests/led_service_tb.sv
@@ -18,7 +18,9 @@ module led_service_tb;
   // Stream genérico (não consumido neste TB)
   resp_stream_if led_stream();
 
-  led_service svc(
+  localparam bit ACTIVE_LOW = 1;
+
+  led_service #(.ACTIVE_LOW(ACTIVE_LOW)) svc(
     .clk(clk), .rst_n(rst_n),
     .frame_valid(frame_valid), .msgType(msgType),
     .led_req(led_req), .leds(leds),
@@ -38,19 +40,19 @@ module led_service_tb;
     led_req.frameId = 8'h01; led_req.ledMask = 8'h3F; led_req.ledValue = 8'h01;
     frame_valid = 1; msgType = LED_CTRL_TYPE; @(posedge clk); frame_valid = 0; @(posedge clk);
     wait_response(8'h01, 8'h3F, 8'h00);
-    `TEST_ASSERT(leds == 6'b111111, "all_on");
+    `TEST_ASSERT(leds == (ACTIVE_LOW ? 6'b000000 : 6'b111111), "all_on");
 
     // Desliga todos os LEDs
     led_req.frameId = 8'h02; led_req.ledMask = 8'h3F; led_req.ledValue = 8'h00;
     frame_valid = 1; msgType = LED_CTRL_TYPE; @(posedge clk); frame_valid = 0; @(posedge clk);
     wait_response(8'h02, 8'h3F, 8'h00);
-    `TEST_ASSERT(leds == 6'b000000, "all_off");
+    `TEST_ASSERT(leds == (ACTIVE_LOW ? 6'b111111 : 6'b000000), "all_off");
 
     // Requisição com LED inexistente
     led_req.frameId = 8'h03; led_req.ledMask = 8'h40; led_req.ledValue = 8'h01;
     frame_valid = 1; msgType = LED_CTRL_TYPE; @(posedge clk); frame_valid = 0; @(posedge clk);
     wait_response(8'h03, 8'h40, 8'h01);
-    `TEST_ASSERT(leds == 6'b000000, "invalid_led_no_change");
+    `TEST_ASSERT(leds == (ACTIVE_LOW ? 6'b111111 : 6'b000000), "invalid_led_no_change");
 
     $display("Sucesso: led_service_tb");
     $finish;

--- a/tb/tests/spi_full_flow_led_20_tb.sv
+++ b/tb/tests/spi_full_flow_led_20_tb.sv
@@ -84,7 +84,9 @@ module spi_full_flow_led_20_tb;
     .led_ctrl_frame(led_ctrl_frame)
   );
 
-  led_service u_led(
+  localparam bit ACTIVE_LOW = 1;
+
+  led_service #(.ACTIVE_LOW(ACTIVE_LOW)) u_led(
     .clk(clk), .rst_n(rst_n),
     .frame_valid(frame_valid), .msgType(out_msgType),
     .led_req(led_ctrl_frame),
@@ -249,7 +251,7 @@ module spi_full_flow_led_20_tb;
     inq = {};
     started = 1'b0;
     messages_sent = 0;
-    expected_leds  = 6'b0;
+    expected_leds  = ACTIVE_LOW ? 6'b111111 : 6'b0;
     repeat (2) @(posedge clk);
     rst_n = 1;
 
@@ -274,7 +276,9 @@ module spi_full_flow_led_20_tb;
       send_led_ctrl_frame(frameIds[i], masks[i], vals[i]);
       messages_sent++;
       // Atualiza modelo esperado de LEDs
-      if (vals[i][0])
+      logic val = vals[i][0];
+      if (ACTIVE_LOW) val = ~val;
+      if (val)
         expected_leds = expected_leds | masks[i][5:0];
       else
         expected_leds = expected_leds & ~masks[i][5:0];

--- a/tb/tests/spi_full_flow_led_basic_tb.sv
+++ b/tb/tests/spi_full_flow_led_basic_tb.sv
@@ -44,7 +44,9 @@ module spi_full_flow_led_basic_tb;
     .move_home_frame(), .start_move_frame(), .move_probe_frame(), .queue_add_frame(), .move_end_frame(),
     .queue_status_frame(), .fpga_status_frame(), .led_ctrl_frame(led_ctrl_frame)
   );
-  led_service u_led(
+  localparam bit ACTIVE_LOW = 1;
+
+  led_service #(.ACTIVE_LOW(ACTIVE_LOW)) u_led(
     .clk(clk), .rst_n(rst_n), .frame_valid(frame_valid), .msgType(out_msgType),
     .led_req(led_ctrl_frame), .leds(leds), .resp_valid(resp_valid), .resp_frame(resp_frame),
     .tx_stream(led_stream)
@@ -84,7 +86,7 @@ module spi_full_flow_led_basic_tb;
     logic [5:0] expected_leds;
 
     // Reset
-    expected_leds = 6'b0;
+    expected_leds = ACTIVE_LOW ? 6'b111111 : 6'b0;
     repeat (2) @(posedge clk); rst_n = 1;
 
     // Programa 10 combinações (liga alguns, desliga outros, e final all-on)
@@ -112,8 +114,10 @@ module spi_full_flow_led_basic_tb;
       cycles = 0; while (!resp_valid && cycles < 100) begin @(posedge clk); cycles++; end
       `TEST_ASSERT(resp_valid, "resp_valid_timeout")
       // Atualiza esperado conforme semântica do serviço
-      if (vals[i][0]) expected_leds = expected_leds |  masks[i][5:0];
-      else            expected_leds = expected_leds & ~masks[i][5:0];
+      logic val = vals[i][0];
+      if (ACTIVE_LOW) val = ~val;
+      if (val) expected_leds = expected_leds |  masks[i][5:0];
+      else     expected_leds = expected_leds & ~masks[i][5:0];
       `TEST_ASSERT(leds == expected_leds, "leds_state_match")
 
       // Captura 7 bytes enviados ao wrapper (via wr_en/wdata)

--- a/tb/tests/spi_led_integration_tb.sv
+++ b/tb/tests/spi_led_integration_tb.sv
@@ -64,7 +64,9 @@ module spi_led_integration_tb;
     .led_ctrl_frame(led_ctrl_frame)
   );
 
-  led_service u_led(
+  localparam bit ACTIVE_LOW = 1;
+
+  led_service #(.ACTIVE_LOW(ACTIVE_LOW)) u_led(
     .clk(clk), .rst_n(rst_n),
     .frame_valid(frame_valid), .msgType(out_msgType),
     .led_req(led_ctrl_frame),
@@ -136,7 +138,7 @@ module spi_led_integration_tb;
       cycles++;
     end
     `TEST_ASSERT(resp_valid, "resp_valid_timeout")
-    `TEST_ASSERT(leds == 6'b000111, "leds_three_on")
+    `TEST_ASSERT(leds == (ACTIVE_LOW ? 6'b111000 : 6'b000111), "leds_three_on")
     `TEST_ASSERT(resp_frame.frameIdEcho == 8'hA1, "resp_frameid_echo")
     `TEST_ASSERT(resp_frame.ledMask == 8'h07, "resp_ledmask_echo")
     `TEST_ASSERT(resp_frame.status == 8'h00, "resp_status_ok")


### PR DESCRIPTION
## Summary
- make LED service support active-low LEDs via `ACTIVE_LOW` parameter
- configure top-level to use active-low LEDs
- update LED tests for active-low polarity

## Testing
- `./run_tests.sh verilator`

------
https://chatgpt.com/codex/tasks/task_e_68c15cc978d08326be87436c4f9abaf3