### PR TITLE
Fix SPI transmit path and enable waveform tracing

### DIFF
--- a/host_py/README.md
+++ b/host_py/README.md
@@ -22,6 +22,11 @@ Verilator simulation
     compatibilidade com Verilator. Para habilitar as versões com interfaces
     (utilizadas nos testbenches ModelSim), compile definindo
     `-DSPI_USE_INTERFACES` — recurso ainda não suportado no Verilator 5.x.
+  - Em caso de *Timeout waiting for response header* ou para depurar o fluxo
+    SPI, o `blink_leds_sim.py` roda com `debug=True` e o transporte Verilator
+    gera o arquivo `blink_leds_sim.vcd` com as ondas dos sinais SPI. Abra esse
+    VCD no [GTKWave](http://gtkwave.sourceforge.net/) para inspecionar as
+    transações e localizar falhas de comunicação.
 
 Usage
 - Status:

--- a/host_py/examples/blink_leds_sim.py
+++ b/host_py/examples/blink_leds_sim.py
@@ -7,8 +7,8 @@ from host_py.verilator_transport import VerilatorSpiTransport
 
 
 def main() -> int:
-    transport = VerilatorSpiTransport()
-    cli = FpgaSpiClient(transport=transport)
+    transport = VerilatorSpiTransport(debug=True)
+    cli = FpgaSpiClient(transport=transport, debug=True)
     cli.open()
     try:
         try:

--- a/host_py/fpga_spi_client.py
+++ b/host_py/fpga_spi_client.py
@@ -220,11 +220,14 @@ class FpgaSpiClient:
         self,
         expect_type: Optional[int],
         timeout_s: float,
-        chunk: int = 32,
+        chunk: int = 8,
         max_bytes: int = 1024,
     ) -> List[int]:
         """
         Repeatedly clocks zeros and accumulates bytes until a full frame is found.
+        `chunk` controls the number of bytes clocked per SPI transaction and is
+        kept small so the FPGA's 16-byte transmit FIFO can't wrap within a single
+        transfer.
         If `expect_type` is set, validates the msgType before returning.
         Raises SpiTimeoutError on timeout, ProtocolError on framing issues.
         """

--- a/host_py/fpga_spi_client.py
+++ b/host_py/fpga_spi_client.py
@@ -165,12 +165,14 @@ class FpgaSpiClient:
         max_speed_hz: int = 1_000_000,
         mode: int = 0,
         transport: Optional[object] = None,
+        debug: bool = False,
     ) -> None:
         """
         If `transport` is provided, it must expose `open()`, `close()` and `xfer(seq)->list`.
         Otherwise a spidev transport is created with the given parameters.
         """
         self._t = transport or _SpiDevWrapper(bus, device, max_speed_hz, mode)
+        self._debug = debug
 
     # Lifecycle ---------------------------------------------------------------
     def open(self) -> None:
@@ -181,10 +183,15 @@ class FpgaSpiClient:
 
     # Primitives --------------------------------------------------------------
     def _write(self, data: Sequence[int]) -> None:
+        if self._debug:
+            print("SPI write:", [f"0x{b:02X}" for b in data])
         self._t.xfer(list(data))  # write-only (MISO ignored)
 
     def _read(self, nbytes: int, fill: int = 0x00) -> List[int]:
-        return self._t.xfer([fill] * nbytes)
+        resp = self._t.xfer([fill] * nbytes)
+        if self._debug:
+            print("SPI read:", [f"0x{b:02X}" for b in resp])
+        return resp
 
     # Maintenance / diagnostics ----------------------------------------------
     def drain(self, nbytes: int = 64, fill: int = 0x00) -> List[int]:
@@ -205,6 +212,8 @@ class FpgaSpiClient:
 
     # Request/Response helpers -----------------------------------------------
     def _send_request(self, req: Sequence[int]) -> None:
+        if self._debug:
+            print("Sending request:", [f"0x{b:02X}" for b in req])
         self._write(req)
 
     def _read_response_stream(
@@ -224,10 +233,15 @@ class FpgaSpiClient:
         while True:
             # Timeout check
             if time.monotonic() - t0 > timeout_s:
+                if self._debug:
+                    print("Timeout, buffer:", [f"0x{b:02X}" for b in buf])
                 raise SpiTimeoutError("Timeout waiting for response header")
 
             # Read a chunk
-            buf.extend(self._read(chunk))
+            chunk_bytes = self._read(chunk)
+            buf.extend(chunk_bytes)
+            if self._debug:
+                print("Accumulated buffer:", [f"0x{b:02X}" for b in buf])
             if len(buf) > max_bytes:
                 raise ProtocolError("Response stream exceeded maximum length")
 

--- a/host_py/verilator_transport.py
+++ b/host_py/verilator_transport.py
@@ -14,10 +14,11 @@ class VerilatorSpiTransport:
     expected by :class:`FpgaSpiClient`.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, debug: bool = False) -> None:
         self.sim = None
         self._tempdir = None
         self._vcd_path = None
+        self.debug = debug
 
     # ------------------------------------------------------------------
     def open(self) -> None:  # pragma: no cover - heavy to simulate in tests
@@ -206,4 +207,8 @@ class VerilatorSpiTransport:
         # aggregator, so provide a generous margin here.
         for _ in range(256):
             self._tick()
+        if self.debug:
+            tx = [f"0x{b:02X}" for b in data]
+            rx = [f"0x{b:02X}" for b in resp]
+            print(f"SPI xfer tx={tx} rx={rx}")
         return resp

--- a/host_py/verilator_transport.py
+++ b/host_py/verilator_transport.py
@@ -17,6 +17,7 @@ class VerilatorSpiTransport:
     def __init__(self) -> None:
         self.sim = None
         self._tempdir = None
+        self._vcd_path = None
 
     # ------------------------------------------------------------------
     def open(self) -> None:  # pragma: no cover - heavy to simulate in tests
@@ -137,6 +138,11 @@ class VerilatorSpiTransport:
             pv_mod.verilator_name_to_standard_modular_name = orig_name_fn
             template_cpp.template_cpp = orig_template_cpp
 
+        # Inicia captura de ondas para depuração
+        trace_path = root / "blink_leds_sim.vcd"
+        self.sim.start_vcd_trace(str(trace_path))
+        self._vcd_path = trace_path
+
         # Reset
         self.sim.io.i_resetn = 0
         self.sim.io.i_clk = 0
@@ -151,6 +157,12 @@ class VerilatorSpiTransport:
         self.sim.io.pi_mosi = 0
 
     def close(self) -> None:  # pragma: no cover - heavy
+        if self.sim is not None:
+            try:
+                self.sim.flush_vcd_trace()
+                self.sim.stop_vcd_trace()
+            except Exception:
+                pass
         self.sim = None
         if self._tempdir is not None:
             self._tempdir.cleanup()

--- a/src/drivers/spi/spi_slave_wrap.sv
+++ b/src/drivers/spi/spi_slave_wrap.sv
@@ -59,7 +59,7 @@ module spi_slave #(
     end else begin
       if (wr_en && (waddr == 3'd0)) begin
         tx_reg <= wdata;
-        if (ss_n_slave && tx_count < 4'd16) begin
+        if (tx_count < 4'd15) begin
           tx_buf[tx_count] <= wdata;
           tx_count <= tx_count + 4'd1;
         end

--- a/src/top.sv
+++ b/src/top.sv
@@ -234,6 +234,12 @@ module top (
 
     // Interface de stream para o motion_service
     resp_stream_if motion_stream();
+    // Serviço de motion não está presente nesta build de simulação,
+    // então publicamos constantes para evitar 'X' propagando pelo
+    // agregador de respostas.
+    assign motion_stream.valid = 1'b0;
+    assign motion_stream.bits  = '0;
+    assign motion_stream.len   = '0;
 
     // -------------------------
     // Agregador de TX sintetizável (2 streams: LED e Motion)
@@ -270,6 +276,9 @@ module top (
     // seleção combinacional do stream
     logic                      pick;
     logic                      pick_idx;       // 0 = LED, 1 = Motion
+    // registradores para escrita no spi_slave
+    logic                      tx_wr_en_r;
+    logic [7:0]                tx_wr_data_r;
 
     // Combinacional: decidir pick e prontos
     always @* begin
@@ -294,12 +303,15 @@ module top (
     // FSM do agregador
     always_ff @(posedge i_clk or negedge i_resetn) begin
       if (!i_resetn) begin
-        tx_state <= IDLE;
-        rr_sel   <= 1'b0;
-        tx_shift <= '0;
-        tx_len   <= '0;
-        tx_idx   <= '0;
+        tx_state     <= IDLE;
+        rr_sel       <= 1'b0;
+        tx_shift     <= '0;
+        tx_len       <= '0;
+        tx_idx       <= '0;
+        tx_wr_en_r   <= 1'b0;
+        tx_wr_data_r <= 8'h00;
       end else begin
+        tx_wr_en_r   <= 1'b0; // desativa por padrão
         unique case (tx_state)
           IDLE: begin
             tx_idx <= '0; // pronto para aceitar novo frame
@@ -312,24 +324,27 @@ module top (
             end
           end
           SEND: begin
-            // Envia 1 byte por ciclo para o spi_slave (endereço 0)
+            // Publica o próximo byte
+            tx_wr_en_r   <= 1'b1;
+            tx_wr_data_r <= tx_shift[SHIFT_BITS-1 -: 8];
             if (tx_idx + 1 >= tx_len) begin
               // último byte neste ciclo → volta ao IDLE no próximo
-              tx_idx  <= '0;
-              tx_state<= IDLE;
+              tx_idx   <= '0;
+              tx_state <= IDLE;
             end else begin
               tx_idx <= tx_idx + 1'b1;
             end
+            // Prepara byte seguinte
+            tx_shift <= {tx_shift[SHIFT_BITS-9:0], 8'd0};
           end
           default: tx_state <= IDLE;
         endcase
       end
     end
 
-    // Pulsos de escrita e dados
     // Pulsos de transmissão para o SPI_Slave
-    assign tx_wr_en   = (tx_state == SEND);
-    assign tx_wr_data = tx_shift[SHIFT_BITS-1 - tx_idx*8 -: 8];
+    assign tx_wr_en   = tx_wr_en_r;
+    assign tx_wr_data = tx_wr_data_r;
 
 
     // -------------------------


### PR DESCRIPTION
## Summary
- correct SPI slave TX queue limit to allow enqueuing bytes
- pipeline top-level TX aggregator with registered write enable/data
- add optional VCD trace generation in Verilator transport for signal debugging

## Testing
- `python - <<'PY'
from host_py.verilator_transport import VerilatorSpiTransport
from host_py.fpga_spi_client import FpgaSpiClient
transport=VerilatorSpiTransport(); transport.open(); cli=FpgaSpiClient(transport=transport)
print(cli.led_control(0x3F,0,1)); print(cli.led_control(0x3F,1,2)); cli.close()
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c57634b4a083268f4bada8512d9539